### PR TITLE
Composer: rm mediawiki, mw-extension-registry-helper, bootstrap

### DIFF
--- a/build/travis/build.sh
+++ b/build/travis/build.sh
@@ -126,6 +126,7 @@ function installSkinViaComposerOnMediaWikiRoot {
 	echo 'ini_set("display_errors", 1);' >> LocalSettings.php
 	echo '$wgShowExceptionDetails = true;' >> LocalSettings.php
 	echo '$wgDevelopmentWarnings = true;' >> LocalSettings.php
+	echo 'wfLoadExtension( "Bootstrap" );' >> LocalSettings.php
 	echo 'wfLoadSkin( "chameleon" );' >> LocalSettings.php
 	echo "putenv( 'MW_INSTALL_PATH=$(pwd)' );" >> LocalSettings.php
 

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,7 @@
 		"php": ">=7.1",
 		"ext-dom": "*",
 		"ext-filter": "*",
-		"composer/installers": "^1.0.12",
-		"mediawiki/mediawiki": ">=1.31",
-		"mediawiki/mw-extension-registry-helper": "^1.0",
-		"mediawiki/bootstrap": "^4.0"
+		"composer/installers": "^1.0.12"
 	},
 	"require-dev": {
 		"php": ">=7.2",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.x-dev"
+			"dev-master": "3.x-dev"
 		}
 	},
 	"scripts": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ If you run into problems, try the
 3. Add the following code at the bottom of your LocalSettings.php:
 
    ```php
-   wfLoadSkin( 'chameleon' );
+   wfLoadSkin( 'Chameleon' );
 	```
 
    To set Chameleon as the default skin, find `$wgDefaultSkin` and amend it:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,19 +2,26 @@
 
 ### Requirements
 
-- PHP 7.0 or later
+- PHP 7.1 or later
 - MediaWiki 1.31 or later
-- [Composer][composer]
-
-Further required software packages will be installed automatically. It is *not*
-necessary to install any dependencies. Composer will take care of that.
 
 ### Installation
+
+There are two methods for installing Chameleon: with or without [Composer][composer].
+
+If you install Chameleon with Composer, further required software packages will be installed
+automatically. In this case, it is *not* necessary to install any dependencies. Composer will
+take care of that.
+
+If you install Chameleon without Composer, you will need to install and enable the
+[Bootstrap extension][bootstrap] before you install and enable Chameleon.
 
 If unsure try the detailed installation instructions for
 [Windows](installation-windows.md) or [Linux](installation-linux.md).
 
 Here is the short version:
+
+#### Installation with Composer
 
 1. On a command line go to your MediaWiki installation directory
 
@@ -52,12 +59,33 @@ depends on.
 If you run into problems, try the
 [troubleshooting](installation-troubleshooting.md).
 
-### Update
+#### Installation without Composer
+
+1. Install and enable the [Bootstrap][bootstrap] extension.
+
+2. [Download][download] Chameleon and place the file(s) in a directory called Chameleon in your
+    skins/ folder.
+
+3. Add the following code at the bottom of your LocalSettings.php:
+
+   ```php
+   wfLoadSkin( 'chameleon' );
+	```
+
+   To set Chameleon as the default skin, find `$wgDefaultSkin` and amend it:
+   ```php
+   $wgDefaultSkin='chameleon';
+   ```
+
+4. __Done:__ Navigate to _Special:Version_ on your wiki to verify that the skin
+   is successfully installed.
+
+### Update with Composer
 
 From your MediaWiki installation directory run `composer update
 "mediawiki/chameleon-skin"`
 
-### De-installation
+### De-installation with Composer
 
 Before de-installation make sure you secure (move, backup) any custom files you
 might want to retain.
@@ -67,3 +95,5 @@ Remove the Chameleon skin from the `composer.local.json` file. Then run
 directory.
 
 [composer]: https://getcomposer.org/
+[bootstrap]: https://www.mediawiki.org/wiki/Extension:Bootstrap
+[download]: https://github.com/ProfessionalWiki/chameleon/archive/master.zip

--- a/skin.json
+++ b/skin.json
@@ -5,12 +5,15 @@
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional.Wiki]"
 	],
-	"version": "2.4.0-alpha",
+	"version": "3.0.0-alpha",
 	"url": "https://www.mediawiki.org/wiki/Skin:Chameleon",
 	"descriptionmsg": "chameleon-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.31.0"
+		"MediaWiki": ">= 1.31.0",
+		"extensions": {
+			"Bootstrap": "4.2"
+		}
 	},
 	"AutoloadNamespaces": {
 		"Skins\\Chameleon\\": "src/",

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -27,7 +27,6 @@
 namespace Skins\Chameleon;
 
 use Bootstrap\BootstrapManager;
-use ExtensionRegistryHelper\ExtensionRegistryHelper;
 use OutputPage;
 use QuickTemplate;
 use ResourceLoader;
@@ -57,8 +56,6 @@ class Chameleon extends SkinTemplate {
 	 * @throws \Exception
 	 */
 	public static function init() {
-		ExtensionRegistryHelper::singleton()->loadExtensionRecursive( 'Bootstrap' );
-
 		/**
 		 * Using callbacks for hook registration
 		 *


### PR DESCRIPTION
This completes the changes that allow Chameleon to be installed without composer.

- Remove the mediawiki/mediawiki, mediawiki/mw-extension-registry-helper, and mediawiki/bootstrap composer packages
- Remove mw-extension-registry-helper code
- Add Bootstrap as a requirement to skin.json
- Bumps Chameleon version to 3.0.0
- Requires a 4.2 release of Bootstrap
- Requires Bootstrap to be enabled manually (e.g. `wfLoadExtension( 'Bootstrap');` in LocalSettings.php)

fixes https://github.com/ProfessionalWiki/chameleon/issues/120
