### PR TITLE
Fixes scroll behaviour for anchor links when sticky navbar is active

### DIFF
--- a/resources/styles/utilities/_sticky.scss
+++ b/resources/styles/utilities/_sticky.scss
@@ -9,3 +9,12 @@
 .sticky {
 	z-index: $zindex-sticky;
 }
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top
+// Fix anchors being hidden under a sticky nav
+.reference,
+.firstHeading,
+h1, h2, h3, h4, h5
+{
+  scroll-margin-top: 120px;
+}


### PR DESCRIPTION
When sticky modification is applied to a navbar it causes issues with anchors

https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top