### PR TITLE
Fix defining $IP in .phan/config.php

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -3,7 +3,7 @@ $cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.
 
 $IP = getenv( 'MW_INSTALL_PATH' ) !== false
 	? str_replace( '\\', '/', getenv( 'MW_INSTALL_PATH' ) )
-	: __DIR__ . '/../../';
+	: __DIR__ . '/../../..';
 
 $cfg['directory_list'] = array_merge(
 	$cfg['directory_list'],


### PR DESCRIPTION
It's currently incorrect when MW_INSTALL_PATH === false

Results in

```
00:09:09 WARNING: Caught exception while listing files in '/mediawiki/skins/chameleon/.phan/../..//extensions/Bootstrap': RecursiveDirectoryIterator::__construct(/mediawiki/skins/chameleon/.phan/../..//extensions/Bootstrap): failed to open dir: No such file or directory
```