### PR TITLE
Do not advise using addToBodyAttributes() method

### DIFF
--- a/src/ChameleonTemplate.php
+++ b/src/ChameleonTemplate.php
@@ -45,7 +45,7 @@ class ChameleonTemplate extends BaseTemplate {
 	public function execute() {
 		// output the head element
 		// The headelement defines the <body> tag itself, it shouldn't be included in the html text
-		// To add attributes or classes to the body tag override addToBodyAttributes() in SkinChameleon
+		// To add attributes or classes to the body tag use OutputPageBodyAttributes hook
 		$this->html( 'headelement' );
 		echo $this->getSkin()->getComponentFactory()->getRootComponent()->getHtml();
 		$this->printTrail();


### PR DESCRIPTION
The parent method will soon be removed. OutputPageBodyAttributes hook is now the  only supported way of adding stuff to the body tag. Note the hook is not new.