### PR TITLE
Update installation-linux.md

### DIFF
--- a/docs/installation-linux.md
+++ b/docs/installation-linux.md
@@ -6,7 +6,7 @@ operating systems as well:
 1. Open a command line window (e.g. using Konsole or XTerm).
 2. If necessary [install Composer][]:
     ``` sh
-    curl -sS https://getcomposer.org/installer | php
+    wget -cO - https://getcomposer.org/composer-1.phar > composer.phar
     sudo mv composer.phar /usr/local/bin/composer
     ```
 3. Navigate to the root folder of your MediaWiki installation. That's the one
@@ -38,7 +38,9 @@ operating systems as well:
    ```
    
 5. To actually install Chameleon run the command
-   `composer update "mediawiki/chameleon-skin"`
+   ```bash
+   COMPOSER=composer.local.json composer require --no-update mediawiki/chameleon-skin:~3.0
+   composer update mediawiki/chameleon-skin --no-dev -o```
 6. If there were no errors, close the command line window.
 7. Open `LocalSettings.php` in an editor (e.g. Kate). Include
    ```php


### PR DESCRIPTION
Mediawiki only supports composer 1.*, but the installation instructions get 2.*

This causes the following error on composer install

```bash
The "wikimedia/composer-merge-plugin" plugin was skipped because it requires a Plugin API version ("^1.0") that does not match your Composer installation ("2.0.0"). You may need to run composer update with the "--no-plugins" option.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - mediawiki/chameleon-skin[2.0, ..., 2.3.0] require mediawiki/mediawiki >=1.31 -> could not be found in any version, there may be a typo in the package name.
    - Root composer.json requires mediawiki/chameleon-skin ~2.0 -> satisfiable by mediawiki/chameleon-skin[2.0, 2.1.0, 2.2.0, 2.3.0].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```

which is solved by using v1.* as prescribed by the mediawiki docs: https://www.mediawiki.org/wiki/Composer

Step 5 also fails with this error:
```bash
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - mediawiki/chameleon-skin 2.3.0 requires mediawiki/mediawiki >=1.31 -> no matching package found.
    - mediawiki/chameleon-skin 2.2.0 requires mediawiki/mediawiki >=1.31 -> no matching package found.
    - mediawiki/chameleon-skin 2.1.0 requires mediawiki/mediawiki >=1.31 -> no matching package found.
    - mediawiki/chameleon-skin 2.0 requires mediawiki/mediawiki >=1.31 -> no matching package found.
    - Installation request for mediawiki/chameleon-skin ~2.0 -> satisfiable by mediawiki/chameleon-skin[2.0, 2.1.0, 2.2.0, 2.3.0].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.

```

 but using the instructions from https://github.com/ProfessionalWiki/chameleon/blob/master/docs/installation.md work