### PR TITLE
`id` may not be defined so check

### DIFF
--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -114,8 +114,9 @@ class NavMenu extends Component {
 			$this->indent( $indent );
 
 			foreach ( $menuDescription['content'] as $key => $item ) {
+				$id = $item['id'] ?? '';
 				$menuitems .= $this->indent() . $this->getSkinTemplate()->makeListItem( $key, $item,
-					[ 'tag' => 'div', 'class' => 'nav-item', 'link-class' => 'nav-link '.$item['id'] ] );
+					[ 'tag' => 'div', 'class' => 'nav-item', 'link-class' => 'nav-link '. $id ] );
 			}
 
 			$this->indent( - $indent );


### PR DESCRIPTION
e.g.
```
$wgHooks['SidebarBeforeOutput'][] = function ( $skin, &$bar ) {
        # note: heading can be either a message key. If no message exists it will be treated as a plain
 text.
        $bar[ 'sunday' ] = [
                [
                        'label' => 'msg-myid',
                        'msg' => 'my-label-message',
                        'href' => '//example.com'
                ]
        ];
};
```

Fixes: #212