### PR TITLE
Make new links colour important

### DIFF
--- a/resources/styles/themes/_light.scss
+++ b/resources/styles/themes/_light.scss
@@ -118,7 +118,7 @@ $h6-font-size:                $font-size-base * 1.0 !default;
 // Links
 $link-color: $cobalt;
 $cmln-link-formats: (
-	new: ('color': $burgundy, 'hover-color': darken($burgundy, 15%)),
+	new: ('color': $burgundy !important, 'hover-color': darken($burgundy, 15%) !important),
 );
 
 // Navbar


### PR DESCRIPTION
The burgundy red for new links gets overwritten by the black link colours for the dropdown menus. This makes the new link colours important and enhances the usability as customers can now see that e.g. the discussion page doesn’t exist yet.

Closes #82