### PR TITLE
Add sticky refresh on page load with fragment

### DIFF
--- a/resources/js/Components/Modifications/sticky.js
+++ b/resources/js/Components/Modifications/sticky.js
@@ -33,6 +33,11 @@
 
     mw.loader.using('skin.chameleon.sticky', function () {
 		$('.sticky').hcSticky( {} );
+
+		// Reposition sticky if the page is loaded with a URI fragment.
+		if ($(location).attr('hash') != '') {
+			$('.sticky').hcSticky('refresh');
+		};
     });
 
 }(window, document, jQuery, mediaWiki) );


### PR DESCRIPTION
Refs: #139
Fixes: #139 

When the page is loaded with a URI fragment the sticky needs to be refreshed to recalculate its position.

Tested with:
* MediaWiki 1.35.2
* Chameleon (master branch)
* Chameleon layout: stickyhead
* Browsers:
  * Firefox 88
  * Chromium 90

When a URL containing a fragment (e.g. `/wiki/Special:Version?uselayout=stickyhead#mw-version-ext`) is opened directly in the address bar, then the sticky will now be repositioned without requiring manual scrolling.