### PR TITLE
Fix empty toolbox in unit tests

### DIFF
--- a/src/Components/NavbarHorizontal/Toolbox.php
+++ b/src/Components/NavbarHorizontal/Toolbox.php
@@ -80,8 +80,10 @@ class Toolbox extends Component {
 
 		if ( version_compare( $wgVersion, '1.35', '<' ) ) {
 			$toolbox = $skinTemplate->getToolbox();
-		} else {
+		} else if ( isset( $skinTemplate->get( 'sidebar' )[ 'TOOLBOX' ] ) ) {
 			$toolbox = $skinTemplate->get( 'sidebar' )[ 'TOOLBOX' ];
+		} else {
+			$toolbox = array();
 		}
 		// FIXME: Do we need to care of dropdown menus here? E.g. RSS feeds?
 		foreach ( $toolbox as $key => $linkItem ) {


### PR DESCRIPTION
@JeroenDeDauw This fixes the failing unit test in the Toolbox component after the merge of my PR:
https://github.com/ProfessionalWiki/chameleon/runs/2534352988

I suppose having an unchecked array key access here wasn't safe in the first place.

Local unit test result with:
* PHP 7.4
* MediaWiki 1.35.2
* Chameleon: master branch

![image](https://user-images.githubusercontent.com/1428594/117540205-49419e80-b00e-11eb-98ab-3ed52e4b22b5.png)
