### PR TITLE
Fixes sticky navbar overlapping section links

### DIFF
--- a/resources/js/Components/Modifications/sticky.js
+++ b/resources/js/Components/Modifications/sticky.js
@@ -35,4 +35,31 @@
 		$('.sticky').hcSticky( {} );
     });
 
+	/* Fixes sticky header overlaps the sections headers on anchor links */
+	$( function () {
+		$( window ).on( 'hashchange', function ( e ) {
+			adjustScroll();
+		} );
+
+		adjustScroll();
+	} );
+
+	function adjustScroll() {
+		var $header = $( 'nav.p-navbar.collapsible.sticky' ),
+			headerHeight = $header.height() + 20,
+			hash = window.location.hash,
+			$target = $( hash );
+
+		if ( !$header.length ) {
+			return;
+		}
+
+		if ( $target.length ) {
+			$( 'html,body' ).animate( {
+				scrollTop: $target.offset().top - headerHeight
+			}, 250 );
+			return false;
+		}
+	}
+
 }(window, document, jQuery, mediaWiki) );


### PR DESCRIPTION
Fixes #138 by adding a modified version of the https://github.com/wikimedia/mediawiki-skins-WikimediaApiPortal/blob/12a4f3a2132913ea9193203853a46c0b367233c2/resources/script/scrollAdjust.js script. The script is loaded together with `hc-sticky` and ensures the document is scrolled in a way that the target section/anchor is visible and is not covered with the sticky navbar