### PR TITLE
Fixes anchor links scroll issue with sticky navbar

### DIFF
--- a/resources/js/Components/Modifications/sticky.js
+++ b/resources/js/Components/Modifications/sticky.js
@@ -32,12 +32,21 @@
     'use strict';
 
     mw.loader.using('skin.chameleon.sticky', function () {
-		$('.sticky').hcSticky( {} );
+		$('.sticky').hcSticky( {
+			onStart: function ( e ) {
+				// The hcSticky does not have any callbacks that we could use
+				// as an indicator of the sticky block being fully attached
+				// so add a little timeout before starting to calculate element height
+				setTimeout( function( e ) {
+					adjustScroll();
+				}, 50 );
+			}
+		} );
 
 		// Reposition sticky if the page is loaded with a URI fragment.
-		if ($(location).attr('hash') != '') {
-			$('.sticky').hcSticky('refresh');
-		};
+	    if ( $( location ).attr( 'hash' ) != '' ) {
+		    $( '.sticky' ).hcSticky( 'refresh' );
+	    }
     });
 
 	/* Fixes sticky header overlaps the sections headers on anchor links */
@@ -45,26 +54,21 @@
 		$( window ).on( 'hashchange', function ( e ) {
 			adjustScroll();
 		} );
-
-		adjustScroll();
 	} );
 
 	function adjustScroll() {
 		var $header = $( 'nav.p-navbar.sticky' ),
 			headerHeight = $header.height() + 20,
-			hash = window.location.hash,
-			$target = $( hash );
+			hash = window.location.hash.replace( '#', '' ),
+			$target = $( '[id="' + hash + '"]' );
 
-		if ( !$header.length ) {
+		if ( !$header.length || !hash || !$target.length ) {
 			return;
 		}
 
-		if ( $target.length ) {
-			$( 'html,body' ).animate( {
-				scrollTop: $target.offset().top - headerHeight
-			}, 250 );
-			return false;
-		}
+		$( 'html,body' ).animate( {
+			scrollTop: $target.offset().top - headerHeight
+		}, 250 );
 	}
 
 }(window, document, jQuery, mediaWiki) );


### PR DESCRIPTION
- Fixes a problem with scrolling to mediawiki h2 headers and anchors containing a `.` (dot) symbol in their `id` attribute
- Fixes a problem with scroll function not calculating sticky navbar height properly due to `hcSticky.refresh` happening after the scroll fix run 