### PR TITLE
Add NavMenu id fix

### DIFF
--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -27,6 +27,7 @@
 namespace Skins\Chameleon\Components;
 
 use Linker;
+use Sanitizer;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -59,6 +60,10 @@ class NavMenu extends Component {
 
 		// create a dropdown for each sidebar box
 		foreach ( $sidebar as $menuName => $menuDescription ) {
+			// Ensure parent menu item has a valid id.
+			$menuDescription['id'] = Sanitizer::escapeIdForAttribute(
+				strtr( $menuDescription['id'], ' ', '-' )
+			);
 			/* @phan-suppress-next-line SecurityCheck-DoubleEscaped */
 			$ret .= $this->getDropdownForNavMenu( $menuName, $menuDescription,
 				array_search( $menuName, $flatten ) !== false );

--- a/tests/phpunit/Unit/Components/GenericComponentTestCase.php
+++ b/tests/phpunit/Unit/Components/GenericComponentTestCase.php
@@ -259,6 +259,11 @@ class GenericComponentTestCase extends TestCase {
 			unset( $matcher[ 'class' ] );
 		}
 
+		if ( array_key_exists( 'id', $matcher ) ) {
+			$query .= '[contains(concat(" ", normalize-space(@id), " "), " ' . $matcher[ 'id' ] . ' ")]';
+			unset( $matcher[ 'id' ] );
+		}
+
 		if ( count( $matcher ) > 0 ) {
 			trigger_error( 'Found unsupported matcher tags: ' . implode( ', ', array_keys( $matcher ) ),
 				E_USER_WARNING );

--- a/tests/phpunit/Unit/Components/NavMenuTest.php
+++ b/tests/phpunit/Unit/Components/NavMenuTest.php
@@ -24,6 +24,8 @@
 
 namespace Skins\Chameleon\Tests\Unit\Components;
 
+use Skins\Chameleon\ChameleonTemplate;
+
 /**
  * @coversDefaultClass \Skins\Chameleon\Components\NavMenu
  * @covers ::<private>
@@ -40,5 +42,39 @@ namespace Skins\Chameleon\Tests\Unit\Components;
 class NavMenuTest extends GenericComponentTestCase {
 
 	protected $classUnderTest = '\Skins\Chameleon\Components\NavMenu';
+
+	/**
+	 * @covers ::getHTML
+	 * @dataProvider domElementProviderFromSyntheticLayoutFiles
+	 */
+	public function testGetHTML_HasValidId( $domElement ) {
+		$chameleonTemplate = $this->getMockBuilder( ChameleonTemplate::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chameleonTemplate->expects( $this->any() )
+			->method( 'getSidebar' )
+			->will( $this->returnValue( [
+				'A long question?!' => [
+					'id' => 'p-A long question?',
+					'header' => 'A long question?',
+					'generated' => 1,
+					'content' => [
+						[
+							'text' => 'An exclamation!',
+							'href' => '/wiki/An_exclamation!',
+							'id' => 'n-An-exclamation.21',
+							'active' => false,
+						]
+					]
+				]
+			] ) );
+
+		/** @var Component $instance */
+		$instance = new $this->classUnderTest( $chameleonTemplate, $domElement );
+
+		self::assertTag( [ 'id' => 'p-A-long-question.3F' ], $instance->getHTML() );
+		self::assertTag( [ 'class' => 'p-A-long-question.3F' ], $instance->getHTML() );
+	}
 
 }


### PR DESCRIPTION
Fixes: #181 

This is the new HTML with a valid id and class:
![image](https://user-images.githubusercontent.com/1428594/118175653-b1d6b400-b430-11eb-8c2e-39b5e2f63c2c.png)
![image](https://user-images.githubusercontent.com/1428594/118175549-8b187d80-b430-11eb-83d4-075bbce796b5.png)
```html
<!-- A long question? -->
<div class="nav-item dropdown">
  <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" data-boundary="viewport">A long question?</a>
  <div class="dropdown-menu p-A-long-question.3F" id="p-A-long-question.3F">
    <div id="n-An-exclamation.21"><a href="/wiki/An_exclamation!" class="nav-link n-An-exclamation.21">An exclamation!</a></div>
  </div>
</div>
```

Not too sure about this unit test, though. Does the mocking here skip too many MW steps? I'm just checking when I get the (mocked) sidebar data as it is currently returned then it will return the better id. However, it does not rely on MW actually generating the current invalid id during test runtime.
