### PR TITLE
Add external link icons support

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -140,3 +140,11 @@ trigger an update of the style cache. There are two ways to do that:
 3. Finally, you can set the following in your `LocalSettings.php` to disable
    caching of SCSS styles completely: `$egScssCacheType = CACHE_NONE;`. This
    should obviously never be done on a production site.    
+
+## Enable external link icons
+
+By default external links will not display the normal MediaWiki icons.
+To enable this, set the following:
+```php
+$egChameleonEnableExternalLinkIcons = true;
+```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,7 @@
 
 Under development
 
-* Added external link icons support (thanks @malberts)
+* Added external link icons support via the new `ChameleonEnableExternalLinkIcons` setting (thanks @malberts)
 * Fixed layout and scroll issues when using the sticky menu and clicking anchor links (thanks @vedmaka)
 * Fixed display of some icons (thanks @malberts and @WouterRademaker)
 * Updated Font Awesome and hc-sticky libraries (thanks @malberts)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 Under development
 
+* Added external link icons support (thanks @malberts)
 * Fixed layout and scroll issues when using the sticky menu and clicking anchor links (thanks @vedmaka)
 * Fixed display of some icons (thanks @malberts and @WouterRademaker)
 * Updated Font Awesome and hc-sticky libraries (thanks @malberts)

--- a/skin.json
+++ b/skin.json
@@ -31,6 +31,9 @@
 		},
 		"ChameleonEnableVisualEditor": {
 			"value": true
+		},
+		"ChameleonEnableExternalLinkIcons": {
+			"value": false
 		}
 	},
 	"ResourceModules": {

--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -260,13 +260,19 @@ class SetupAfterCache {
 	protected function registerSkinWithMW() {
 		MediaWikiServices::getInstance()->getSkinFactory()->register( 'chameleon', 'Chameleon',
 			function () {
+				$styles = [
+					'mediawiki.ui.button',
+					'skins.chameleon',
+					'zzz.ext.bootstrap.styles',
+				];
+
+				if ( $this->configuration[ 'egChameleonEnableExternalLinkIcons' ] === true ) {
+					array_unshift( $styles, 'mediawiki.skinning.content.externallinks' );
+				}
+
 				return new Chameleon( [
 					'name' => 'chameleon',
-					'styles' => [
-						'mediawiki.ui.button',
-						'skins.chameleon',
-						'zzz.ext.bootstrap.styles',
-					]
+					'styles' => $styles
 				] );
 			} );
 	}


### PR DESCRIPTION
Fixes: #183 

Added new LocalSettings variable: `egChameleonEnableExternalLinkIcons`.
The default behaviour is to not show the icons in order to maintain backward compatibility.

When the variable is set to true it will load the MediaWiki external links styling: https://github.com/wikimedia/mediawiki/blob/master/resources/src/mediawiki.skinning/content.externallinks.less