### PR TITLE
Update GitHub pages schema ns

### DIFF
--- a/schema/1.0/layout.rng
+++ b/schema/1.0/layout.rng
@@ -25,7 +25,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 <grammar
 		xmlns="http://relaxng.org/ns/structure/1.0"
 		xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-		ns="https://cmln.github.io/chameleon/schema/1.0/layout.rng"
+		ns="https://ProfessionalWiki.github.io/chameleon/schema/1.0/layout.rng"
 		datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
 >
 

--- a/schema/1.1/layout.rng
+++ b/schema/1.1/layout.rng
@@ -25,7 +25,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 <grammar
 		xmlns="http://relaxng.org/ns/structure/1.0"
 		xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-		ns="https://cmln.github.io/chameleon/schema/1.0/layout.rng"
+		ns="https://ProfessionalWiki.github.io/chameleon/schema/1.0/layout.rng"
 		datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
 >
 

--- a/schema/1.2/layout.rng
+++ b/schema/1.2/layout.rng
@@ -25,7 +25,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 <grammar
 		xmlns="http://relaxng.org/ns/structure/1.0"
 		xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-		ns="https://cmln.github.io/chameleon/schema/1.0/layout.rng"
+		ns="https://ProfessionalWiki.github.io/chameleon/schema/1.0/layout.rng"
 		datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
 >
 

--- a/schema/3.0/layout.rng
+++ b/schema/3.0/layout.rng
@@ -25,7 +25,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 <grammar
 		xmlns="http://relaxng.org/ns/structure/1.0"
 		xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-		ns="https://cmln.github.io/chameleon/schema/3.0/layout.rng"
+		ns="https://ProfessionalWiki.github.io/chameleon/schema/3.0/layout.rng"
 		datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
 >
 


### PR DESCRIPTION
The layout validation fails and it seems like it is because the remote schema (on GitHub pages) still references the old URL.

```
root@f4506d3d0e38:/var/www/html/skins/chameleon# php maintenance/validateLayout.php layouts/standard.xml 
layouts/standard.xml: 
Error 17: Element structure has wrong namespace: expecting https://cmln.github.io/chameleon/schema/3.0/layout.rng in /var/www/html/skins/chameleon/layouts/standard.xml on line 26
```
