### PR TITLE
Allow breakpoint overrides

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 Under development
 
+* Added grid breakpoint override support via the new `$cmln-grid-breakpoints` SCSS variable (thanks @malberts)
 * Added external link icons support via the new `ChameleonEnableExternalLinkIcons` setting (thanks @malberts)
 * Fixed layout and scroll issues when using the sticky menu and clicking anchor links (thanks @vedmaka)
 * Fixed display of some icons (thanks @malberts and @WouterRademaker)

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1740,7 +1740,6 @@ Example with the `cmln` breakpoint:
 $egChameleonExternalStyleVariables = [
         'cmln-grid-breakpoints' => '(xs: 0, sm: 576px, md: 768px, lg: 992px, cmln: 1105px, xl: 1900px)'
 ];
-
 ```
 
 In both cases the original `$cmln-collapse-point` variable used for setting the `cmln` breakpoint size will be ignored.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -134,6 +134,7 @@ non-default values in the order of occurence in the SCSS code.
  $cmln-first-heading-margin-bottom                     | 1rem
  $cmln-first-heading-underline-color                   | rgba(0, 0, 0, 0.1)
  $cmln-first-heading-underline-width                   | 1px
+ $cmln-grid-breakpoints                                | (xs: 0, sm: 576px, md: 768px, lg: 992px, cmln: 1105px, xl: 1200px)
  $cmln-icon-margin                                     | 0.5rem
  $cmln-icons                                           | (go-btn: fas fa-share, search-btn: fas fa-search, navbar-toggler: fas fa-bars, navbar-tool-link: fas fa-asterisk, navbar-more-tools: fas fa-ellipsis-h, navbar-usernotloggedin: fas fa-user, navbar-userloggedin: fas fa-user, ca-cargo-purge: fas fa-redo, ca-delete: fas fa-trash-alt, ca-edit: far fa-edit, ca-formedit: far fa-edit, ca-history: fas fa-history, ca-move: fas fa-location-arrow, ca-nstab-category: fas fa-layer-group, ca-nstab-concept: fas fa-puzzle-piece, ca-nstab-form: fas fa-address-card, ca-nstab-geojson: fas fa-globe, ca-nstab-help: fas fa-question, ca-nstab-image: far fa-file-image, ca-nstab-main: far fa-file, ca-nstab-mediawiki: fas fa-cogs, ca-nstab-project: fas fa-project-diagram, ca-nstab-rule: fas fa-ruler, ca-nstab-special: fas fa-cogs, ca-nstab-template: fas fa-stamp, ca-nstab-user: far fa-user, ca-nstab-widget: fas fa-drafting-compass, ca-protect: fas fa-lock, ca-purge: fas fa-redo, ca-recreatedata: fas fa-database, ca-talk: far fa-comments, ca-unprotect: fas fa-lock, ca-unwatch: far fa-eye-slash, ca-ve-edit: far fa-edit, ca-viewsource: fas fa-code, ca-watch: far fa-eye, feedlink: fas fa-rss, interlanguage-link-target: fas fa-flag, mw-navigation: fas fa-directions, n-Homepage: fas fa-home, n-IRC: fas fa-hashtag, n-Index: fas fa-th, n-List-of-files-with-duplicates: fas fa-check-double, n-Slack: fab fa-slack, n-Uncategorized-files: fas fa-object-ungroup, n-help-mediawiki: fas fa-question, n-help: fas fa-question, n-mainpage-description: fas fa-home, n-mainpage: fas fa-home, n-newfiles: fas fa-images, n-newimages: fas fa-seedling, n-newpages: fas fa-seedling, n-portal: fas fa-archway, n-randompage: fas fa-random, n-recentchanges: fas fa-backward, n-upload: fas fa-upload, p-lang-toggle: fas fa-language, p-tb-toggle: fas fa-toolbox, pt-anoncontribs: fas fa-question, pt-anontalk: fas fa-comments, pt-createaccount: fas fa-user-plus, pt-login: fas fa-sign-in-alt, pt-logout: fas fa-sign-out-alt, pt-mycontris: fas fa-question, pt-mytalk: fas fa-comments, pt-notifications-alert: fas fa-bell, pt-notifications-notice: fas fa-inbox, pt-preferences: fas fa-sliders-h, pt-userpage: fas fa-home, pt-watchlist: far fa-eye, t-blockip: fas fa-user-slash, t-cargopagevalueslink: fas fa-thermometer-half, t-cite: fas fa-question, t-contributions: fas fa-user-edit, t-emailuser: fas fa-at, t-info: fas fa-info, t-log: fas fa-clipboard-list, t-permalink: fas fa-link, t-print: fas fa-print, t-recentchanges: fas fa-clock, t-recentchangeslinked: fas fa-backward, t-smwbrowselink: fas fa-compass, t-specialpages: fas fa-cogs, t-upload: fas fa-upload, t-userrights: fas fa-users, t-wb-concept-uri: fas fa-stroopwafel, t-whatlinkshere: fas fa-sitemap, t-wikibase: fas fa-stroopwafel)
  $cmln-link-colors                                     | (new: #dc3545 none #a71d2a underline, stub: #1b599b none #10345a underline, extiw: #1b599b none #10345a underline, external: #1b599b none #10345a underline)
@@ -1363,7 +1364,6 @@ non-default values in the order of occurence in the SCSS code.
  $gray-900                                             | #212529
  $grays                                                | ("100": #f8f9fa, "200": #e9ecef, "300": #dee2e6, "400": #ced4da, "500": #adb5bd, "600": #6c757d, "700": #495057, "800": #343a40, "900": #212529)
  $green                                                | #28a745
- $grid-breakpoints                                     | (xs: 0, sm: 576px, md: 768px, lg: 992px, cmln: 1105px, xl: 1200px)
  $grid-columns                                         | 12
  $grid-gutter-width                                    | 30px
  $h1-font-size                                         | 2.2rem
@@ -1716,3 +1716,31 @@ non-default values in the order of occurence in the SCSS code.
  $zindex-popover                                       | 1060
  $zindex-sticky                                        | 1020
  $zindex-tooltip                                       | 1070
+
+## Notes about specific variables
+
+### Grid breakpoints
+
+When overriding `$cmln-grid-breakpoints` you must either:
+* include the default `cmln` breakpoint; or
+* additionally set the NavbarHorizontal component's breakpoint variable `$cmln-navbar-horizontal-collapse-point` to one of the other breakpoint names
+
+Example without the `cmln` breakpoint and with the navbar breakpoint set to `lg` instead:
+
+```php
+$egChameleonExternalStyleVariables = [
+	'cmln-navbar-horizontal-collapse-point' => 'lg',
+	'cmln-grid-breakpoints' => '(xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1900px)'
+];
+```
+
+Example with the `cmln` breakpoint:
+
+```php
+$egChameleonExternalStyleVariables = [
+        'cmln-grid-breakpoints' => '(xs: 0, sm: 576px, md: 768px, lg: 992px, cmln: 1105px, xl: 1900px)'
+];
+
+```
+
+In both cases the original `$cmln-collapse-point` variable used for setting the `cmln` breakpoint size will be ignored.

--- a/resources/styles/Components/NavbarHorizontal.scss
+++ b/resources/styles/Components/NavbarHorizontal.scss
@@ -19,7 +19,7 @@
 		.navbar-collapse {
 
 			@extend .flex-column;
-			@extend .flex-cmln-row;
+			@extend .flex-#{$cmln-navbar-horizontal-collapse-point}-row;
 
 			&.show, &.collapsing {
 
@@ -56,8 +56,8 @@
 	.navbar-nav {
 
 		&.right {
-			@extend .ml-cmln-auto;
-			@extend .mt-cmln-0;
+			@extend .ml-#{$cmln-navbar-horizontal-collapse-point}-auto;
+			@extend .mt-#{$cmln-navbar-horizontal-collapse-point}-0;
 			@extend .mt-4;
 			@extend .flex-row;
 			@extend .justify-content-center;
@@ -149,7 +149,7 @@
 			}
 		}
 	}
-	
+
 	a.navbar-more-tools, a.navbar-usernotloggedin, a.navbar-userloggedin, a.navbar-tool-link, a:visited.navbar-tool-link {
 		    color: $navbar-light-color;
 	}

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -19,15 +19,16 @@
 
 $cmln-collapse-point: 1105px !default;
 
-$grid-breakpoints: (
+$cmln-grid-breakpoints: (
 	xs: 0,
 	sm: 576px,
 	md: 768px,
 	lg: 992px,
 	cmln: $cmln-collapse-point,
 	xl: 1200px
-);
+) !default;
 
+$grid-breakpoints: $cmln-grid-breakpoints;
 
 // Global textual link colors.
 $cmln-link-format: $link-color none darken($link-color, 15%) underline !default;


### PR DESCRIPTION
Fixes: #221 

## Tests
## Without `LocalSettings.php` override
![image](https://user-images.githubusercontent.com/1428594/118857602-847a8200-b8d8-11eb-8f12-226770f2100a.png)

## With `cmln` override
```php
$egChameleonExternalStyleVariables = [
	'cmln-grid-breakpoints' => '(xs: 0, sm: 576px, md: 768px, lg: 992px, cmln: 1234px, xl: 1900px)'
];
```
![image](https://user-images.githubusercontent.com/1428594/118857857-cacfe100-b8d8-11eb-9388-892f2f747ade.png)

## Without `cmln` override:
```php
$egChameleonExternalStyleVariables = [
	'cmln-navbar-horizontal-collapse-point' => 'lg',
	'cmln-grid-breakpoints' => '(xs: 0, sm: 500px, md: 800px, lg: 1000px, xl: 1900px)'
];
```
![image](https://user-images.githubusercontent.com/1428594/118858090-0bc7f580-b8d9-11eb-92bf-b41ea3c38bb9.png)

## With everything overridden:
```php
$egChameleonExternalStyleVariables = [
	'cmln-navbar-horizontal-collapse-point' => 'medium',
	'cmln-grid-breakpoints' => '(nothing: 0, small: 123px, medium: 456px, large: 789px, extra-large: 2000px)'
];
```
![image](https://user-images.githubusercontent.com/1428594/118858385-66615180-b8d9-11eb-8b11-3ca9b7a7f2f5.png)
(This is not necessarily sufficient as there are other Bootstrap variables that might need to be adjusted to accommodate such an extreme change.)
