### PR TITLE
Add initial theme support

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -51,9 +51,10 @@ the [documentation of the components](components.md) and at the exisiting
 By default Chameleon comes with a light theme. It is possible to override that
 by setting the `$egChameleonThemeFile` variable.
 
-To reset the theme back to Bootstrap defaults, set it to the bundled empty theme:
+To reset the theme back to Bootstrap defaults, set it to an empty string in
+`LocalSettings.php`:
 ```php
-$egChameleonThemeFile = 'resources/styles/themes/_empty.scss';
+$egChameleonThemeFile = '';
 ```
 
 To use a predefined theme set it to the applicable scss file. This can be used
@@ -64,7 +65,7 @@ totally replace the default light styling with a project-specific theme.
 Download the [United theme](https://bootswatch.com/4/united/) `_variables.scss`
 file and save it in the MediaWiki directory under `themes/united.scss`
 
-Add the following to load it:
+Add the following to `LocalSettings.php`:
 ```php
 $egChameleonThemeFile = __DIR__ . '/themes/united.scss';
 ```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -46,6 +46,29 @@ You can of course also define and use your own layout. To start have a look at
 the [documentation of the components](components.md) and at the exisiting
 [layout description files](../layouts).
 
+## Changing themes
+
+By default Chameleon comes with a light theme. It is possible to override that
+by setting the `$egChameleonThemeFile` variable.
+
+To reset the theme back to Bootstrap defaults, set it to the bundled empty theme:
+```php
+$egChameleonThemeFile = 'resources/styles/themes/_empty.scss';
+```
+
+To use a predefined theme set it to the applicable scss file. This can be used
+to load an existing theme from [Bootswatch](https://bootswatch.com/4) or to 
+totally replace the default light styling with a project-specific theme.
+
+### Bootswatch 4 example
+Download the [United theme](https://bootswatch.com/4/united/) `_variables.scss`
+file and save it in the MediaWiki directory under `themes/united.scss`
+
+Add the following to load it:
+```php
+$egChameleonThemeFile = __DIR__ . '/themes/united.scss';
+```
+
 ## Changing styles: Fonts, Colors, Padding etc.
 
 You can customize the styles of the skin by 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -46,12 +46,12 @@ You can of course also define and use your own layout. To start have a look at
 the [documentation of the components](components.md) and at the exisiting
 [layout description files](../layouts).
 
-## Changing themes
+## Changing styles: Themes
 
-By default Chameleon comes with a light theme. It is possible to override that
-by setting the `$egChameleonThemeFile` variable. This can either be an empty
-string to restore Bootstrap defaults or it can be an absolute path to a SCSS
-file.
+A theme is a collection of predefined styles and by default Chameleon comes
+with a light theme. It is possible to override that by setting the
+`$egChameleonThemeFile` variable. This can either be an empty string to
+restore Bootstrap defaults or it can be an absolute path to a SCSS file.
 
 This can be used to load an existing Bootstrap theme from somewhere like
 [Bootswatch](https://bootswatch.com/4) or to totally replace the default

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -76,7 +76,7 @@ To also load the additional `_bootswatch.scss`, save it to
 `themes/united_bootswatch.scss` and add the following:
 ```php
 $egChameleonExternalStyleModules = [
-	__DIR__ . "/themes/united_bootswatch.scss" => "afterMain",
+	__DIR__ . '/themes/united_bootswatch.scss' => 'afterMain',
 ];
 ```
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -72,6 +72,13 @@ Add the following to `LocalSettings.php`:
 ```php
 $egChameleonThemeFile = __DIR__ . '/themes/united.scss';
 ```
+To also load the additional `_bootswatch.scss`, save it to 
+`themes/united_bootswatch.scss` and add the following:
+```php
+$egChameleonExternalStyleModules = [
+	__DIR__ . "/themes/united_bootswatch.scss" => "afterMain",
+];
+```
 
 ## Changing styles: Fonts, Colors, Padding etc.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -49,19 +49,22 @@ the [documentation of the components](components.md) and at the exisiting
 ## Changing themes
 
 By default Chameleon comes with a light theme. It is possible to override that
-by setting the `$egChameleonThemeFile` variable.
+by setting the `$egChameleonThemeFile` variable. This can either be an empty
+string to restore Bootstrap defaults or it can be an absolute path to a SCSS
+file.
 
+This can be used to load an existing Bootstrap theme from somewhere like
+[Bootswatch](https://bootswatch.com/4) or to totally replace the default
+light styling with a project-specific theme.
+
+### Example: Bootstrap defaults
 To reset the theme back to Bootstrap defaults, set it to an empty string in
 `LocalSettings.php`:
 ```php
 $egChameleonThemeFile = '';
 ```
 
-To use a predefined theme set it to the applicable scss file. This can be used
-to load an existing theme from [Bootswatch](https://bootswatch.com/4) or to 
-totally replace the default light styling with a project-specific theme.
-
-### Bootswatch 4 example
+### Example: Bootswatch 4
 Download the [United theme](https://bootswatch.com/4/united/) `_variables.scss`
 file and save it in the MediaWiki directory under `themes/united.scss`
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 Under development
 
+* Added theme support via the new `ChameleonThemeFile` setting (thanks @malberts)
 * Added external link icons support via the new `ChameleonEnableExternalLinkIcons` setting (thanks @malberts)
 * Fixed layout and scroll issues when using the sticky menu and clicking anchor links (thanks @vedmaka)
 * Fixed display of some icons (thanks @malberts and @WouterRademaker)

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -190,6 +190,9 @@ $list-bullet-size: 0.5 * $font-size-base;
 $list-bullet-color: $gray-300;
 $list-level-indent: 3.5ex;
 
+// Non-Bootstrap variables previously defined in _light.scss
+$error: $danger !default;
+
 /// ==> From Chameleon 1
 
 $thumbnail-caption-padding: 3px;

--- a/resources/styles/themes/_empty.scss
+++ b/resources/styles/themes/_empty.scss
@@ -1,0 +1,7 @@
+//
+// An empty theme that will inherit Bootstrap defaults.
+//
+// This file is part of the MediaWiki skin Chameleon.
+// @copyright 2021, Morne Alberts, GNU General Public License, version 3 (or any later version)
+//
+// @since 3.2

--- a/resources/styles/themes/_empty.scss
+++ b/resources/styles/themes/_empty.scss
@@ -1,7 +1,0 @@
-//
-// An empty theme that will inherit Bootstrap defaults.
-//
-// This file is part of the MediaWiki skin Chameleon.
-// @copyright 2021, Morne Alberts, GNU General Public License, version 3 (or any later version)
-//
-// @since 3.2

--- a/skin.json
+++ b/skin.json
@@ -29,6 +29,10 @@
 			"path": true,
 			"value": "layouts/standard.xml"
 		},
+		"ChameleonThemeFile": {
+			"path": true,
+			"value": "resources/styles/themes/_light.scss"
+		},
 		"ChameleonEnableVisualEditor": {
 			"value": true
 		},

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -94,9 +94,9 @@ class Chameleon extends SkinTemplate {
 		}
 
 		// set default skin theme
-		if ( $GLOBALS[ 'egChameleonThemeFile' ][0] !== '/' ) {
-			$GLOBALS[ 'egChameleonThemeFile' ] = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' .
-				$GLOBALS[ 'egChameleonThemeFile' ];
+		$themeFile = &$GLOBALS[ 'egChameleonThemeFile' ];
+		if ( !empty( $themeFile ) && $themeFile[0] !== '/' ) {
+			$themeFile = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' . $themeFile;
 		}
 	}
 

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -95,7 +95,7 @@ class Chameleon extends SkinTemplate {
 
 		// set default skin theme
 		$themeFile = &$GLOBALS[ 'egChameleonThemeFile' ];
-		if ( !empty( $themeFile ) && $themeFile[0] !== '/' ) {
+		if ( DIRECTORY_SEPARATOR === '/' && !empty( $themeFile ) && $themeFile[0] !== '/' ) {
 			$themeFile = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' . $themeFile;
 		}
 	}

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -92,12 +92,6 @@ class Chameleon extends SkinTemplate {
 			$GLOBALS[ 'egChameleonLayoutFile' ] = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' .
 				$GLOBALS[ 'egChameleonLayoutFile' ];
 		}
-
-		// set default skin theme
-		$themeFile = &$GLOBALS[ 'egChameleonThemeFile' ];
-		if ( DIRECTORY_SEPARATOR === '/' && !empty( $themeFile ) && $themeFile[0] !== '/' ) {
-			$themeFile = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' . $themeFile;
-		}
 	}
 
 	/**

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -92,6 +92,12 @@ class Chameleon extends SkinTemplate {
 			$GLOBALS[ 'egChameleonLayoutFile' ] = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' .
 				$GLOBALS[ 'egChameleonLayoutFile' ];
 		}
+
+		// set default skin theme
+		if ( $GLOBALS[ 'egChameleonThemeFile' ][0] !== '/' ) {
+			$GLOBALS[ 'egChameleonThemeFile' ] = $GLOBALS[ 'wgStyleDirectory' ] . '/chameleon/' .
+				$GLOBALS[ 'egChameleonThemeFile' ];
+		}
 	}
 
 	/**
@@ -199,5 +205,13 @@ class Chameleon extends SkinTemplate {
 	 */
 	protected function getLayoutFilePath() {
 		return $GLOBALS[ 'egChameleonLayoutFile' ];
+	}
+
+	/**
+	 * Template method that can be overridden by subclasses
+	 * @return string Path to theme file
+	 */
+	protected function getThemeFilePath() {
+		return $GLOBALS[ 'egChameleonThemeFile' ];
 	}
 }

--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -107,9 +107,11 @@ class SetupAfterCache {
 	protected function registerCommonBootstrapModules() {
 		$this->bootstrapManager->addAllBootstrapModules();
 
-		$this->bootstrapManager->addStyleFile(
-			$this->configuration[ 'egChameleonThemeFile' ], 'beforeVariables'
-		);
+		if ( !empty( $this->configuration[ 'egChameleonThemeFile' ] ) ) {
+			$this->bootstrapManager->addStyleFile(
+				$this->configuration[ 'egChameleonThemeFile' ], 'beforeVariables'
+			);
+		}
 
 		$this->bootstrapManager->addStyleFile(
 			$this->configuration[ 'chameleonLocalPath' ] .

--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -107,10 +107,8 @@ class SetupAfterCache {
 	protected function registerCommonBootstrapModules() {
 		$this->bootstrapManager->addAllBootstrapModules();
 
-		// FIXME: Make configurable, e.g. in LocalSettings.php
 		$this->bootstrapManager->addStyleFile(
-			$this->configuration[ 'chameleonLocalPath' ] .
-				'/resources/styles/themes/_light.scss', 'beforeVariables'
+			$this->configuration[ 'egChameleonThemeFile' ], 'beforeVariables'
 		);
 
 		$this->bootstrapManager->addStyleFile(

--- a/tests/phpunit/Unit/ChameleonTemplateTest.php
+++ b/tests/phpunit/Unit/ChameleonTemplateTest.php
@@ -48,15 +48,18 @@ class ChameleonTemplateTest extends TestCase {
 	// This is to ensure that the original value is cached since we are unable
 	// to inject the setting during testing
 	protected $egChameleonLayoutFile = null;
+	protected $egChameleonThemeFile = null;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->egChameleonLayoutFile = $GLOBALS['egChameleonLayoutFile'];
+		$this->egChameleonThemeFile = $GLOBALS['egChameleonThemeFile'];
 	}
 
 	protected function tearDown(): void {
 		$GLOBALS['egChameleonLayoutFile'] = $this->egChameleonLayoutFile;
+		$GLOBALS['egChameleonThemeFile'] = $this->egChameleonThemeFile;
 
 		parent::tearDown();
 	}

--- a/tests/phpunit/Unit/Hooks/SetupAfterCacheTest.php
+++ b/tests/phpunit/Unit/Hooks/SetupAfterCacheTest.php
@@ -109,7 +109,7 @@ class SetupAfterCacheTest extends TestCase {
 
 		$configuration = [
 			'egChameleonExternalStyleModules' => $mixedExternalStyleModules,
-			'egChameleonThemeFile'            => 'somepath',
+			'egChameleonThemeFile'            => $this->dummyExternalModule,
 			'IP'                              => 'notTestingIP',
 			'wgScriptPath'                    => 'notTestingwgScriptPath',
 			'wgStyleDirectory'                => 'notTestingwgStyleDirectory',

--- a/tests/phpunit/Unit/Hooks/SetupAfterCacheTest.php
+++ b/tests/phpunit/Unit/Hooks/SetupAfterCacheTest.php
@@ -109,6 +109,7 @@ class SetupAfterCacheTest extends TestCase {
 
 		$configuration = [
 			'egChameleonExternalStyleModules' => $mixedExternalStyleModules,
+			'egChameleonThemeFile'            => 'somepath',
 			'IP'                              => 'notTestingIP',
 			'wgScriptPath'                    => 'notTestingwgScriptPath',
 			'wgStyleDirectory'                => 'notTestingwgStyleDirectory',


### PR DESCRIPTION
I'm not sure if the original intent behind theme support was to have out-of-the-box named themes like "light" and "dark" (or like Bootswatch), or whether it was meant to allow the administrator to more explicitly replace the `_light` theme in a dedicated theme variable as opposed to the more generic `$egChameleonExternalStyleModules`. This PR takes the former approach with a new variable `$egChameleonThemeFile`.

I want a quick way to remove most/all of Chameleon's default styles (i.e. by simply not loading the default theme) and at the moment at least 2 issues are caused by the `_light` theme overriding a `!default` variable which prevents it from being overridden in `LocalSettings.php`.
#182 - `link-color`: https://github.com/ProfessionalWiki/chameleon/blob/master/resources/styles/themes/_light.scss#L119
#219 - `cmln-link-formats`: https://github.com/ProfessionalWiki/chameleon/blob/master/resources/styles/themes/_light.scss#L120

Any thoughts?