### PR TITLE
fix LangLinks.php .$linkItem['id'] error

### DIFF
--- a/src/Components/NavbarHorizontal/LangLinks.php
+++ b/src/Components/NavbarHorizontal/LangLinks.php
@@ -88,7 +88,7 @@ class LangLinks extends Component {
 				$linkItem['class'] = 'nav-item';
 			}
 			$listItems[] = $this->indent() . $skinTemplate->makeListItem( $key, $linkItem,
-				[ 'link-class' => 'nav-link '.$linkItem['id'] , 'tag' => 'div' ] );
+				[ 'link-class' => 'nav-link ' , 'tag' => 'div' ] );
 		}
 
 		$this->indent( -2 );


### PR DESCRIPTION
I have been a bit too enthusiastic in #194
.$linkItem['id'] is not needed in Components/NavbarHorizontal/LangLinks.php and gives an error message 
"Notice
: Undefined index: id in
......../skins/chameleon/src/Components/NavbarHorizontal/LangLinks.php
on line 91