### PR TITLE
Raise minimum: MW 1.35

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_31'
-            php: 7.1
-          - mw: 'REL1_34'
-            php: 7.4
           - mw: 'REL1_35'
             php: 7.4
           - mw: 'REL1_36'

--- a/composer.json
+++ b/composer.json
@@ -31,20 +31,20 @@
 		"irc": "irc://libera.chat:6667/mediawiki"
 	},
 	"require": {
-		"php": ">=7.1",
+		"php": ">=7.3.19",
 		"ext-dom": "*",
 		"ext-filter": "*",
 		"composer/installers": "^1.0.12",
-		"mediawiki/bootstrap": "^4.2"
+		"mediawiki/bootstrap": "^4.5"
 	},
 	"require-dev": {
-		"php": ">=7.2",
+		"php": ">=7.3.19 ",
 		"mediawiki/mediawiki-codesniffer": "36.0.0",
 		"mediawiki/mediawiki-phan-config": "0.10.6"
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.x-dev"
+			"dev-master": "4.x-dev"
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,14 @@
 		"irc": "irc://libera.chat:6667/mediawiki"
 	},
 	"require": {
-		"php": ">=7.3.19",
+		"php": ">=7.4.3",
 		"ext-dom": "*",
 		"ext-filter": "*",
 		"composer/installers": "^1.0.12",
 		"mediawiki/bootstrap": "^4.5"
 	},
 	"require-dev": {
-		"php": ">=7.3.19 ",
+		"php": ">=7.4.3",
 		"mediawiki/mediawiki-codesniffer": "36.0.0",
 		"mediawiki/mediawiki-phan-config": "0.10.6"
 	},

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,8 +2,8 @@
 
 ### Requirements
 
-- PHP 7.1 or later
-- MediaWiki 1.31 or later
+- PHP 7.3.19 or later
+- MediaWiki 1.35 or later
 
 ### Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ### Requirements
 
-- PHP 7.3.19 or later
+- PHP 7.4.3 or later
 - MediaWiki 1.35 or later
 
 ### Installation

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,7 @@ Under development.
 
 * Raised minimum Bootstrap extension version from 4.2 to 4.5
 * Raised minimum MediaWiki version from 1.31 to 1.35
-* Raised minimum PHP version from 7.1 to 7.3.19
+* Raised minimum PHP version from 7.1 to 7.4.3
 
 ### Chameleon 3.2.1
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,13 @@
 ## Release Notes
 
+### Chameleon 4.0.0
+
+Under development.
+
+* Raised minimum Bootstrap extension version from 4.2 to 4.5
+* Raised minimum MediaWiki version from 1.31 to 1.35
+* Raised minimum PHP version from 7.1 to 7.3.19
+
 ### Chameleon 3.2.1
 
 Released on June 3, 2021.

--- a/skin.json
+++ b/skin.json
@@ -6,14 +6,14 @@
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional.Wiki]"
 	],
-	"version": "3.2.1",
+	"version": "4.0.0",
 	"url": "https://www.mediawiki.org/wiki/Skin:Chameleon",
 	"descriptionmsg": "chameleon-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.31.0",
+		"MediaWiki": ">= 1.35.0",
 		"extensions": {
-			"Bootstrap": "~4.2"
+			"Bootstrap": "~4.5"
 		}
 	},
 	"AutoloadNamespaces": {

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -50,9 +50,6 @@ class Chameleon extends SkinTemplate {
 
 	private $componentFactory;
 
-	// FIXME: Remove when MW 1.31 compatibility is dropped
-	private $stylesHaveBeenProcessed = false;
-
 	/**
 	 * @throws \Exception
 	 */

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -95,37 +95,6 @@ class Chameleon extends SkinTemplate {
 	}
 
 	/**
-	 * @return array Array of modules
-	 */
-	public function getDefaultModules() {
-		global $wgVersion;
-
-		$modules = parent::getDefaultModules();
-
-		if ( version_compare( $wgVersion, '1.35', '<' ) ) {
-			// Not necessary in 1.35 (see #110)
-			$modulePos = array_search( 'mediawiki.legacy.shared', $modules[ 'styles' ][ 'core' ] );
-
-			if ( $modulePos !== false ) {
-				// we have our own version of these styles
-				unset( $modules[ 'styles' ][ 'core' ][ $modulePos ] );
-			}
-
-			// These are added in SetupAfterCache::registerSkinWithMW in >= 1.35
-			$modules[ 'styles' ][ 'content' ][] = 'mediawiki.skinning.content';
-			$modules[ 'styles' ][ 'content' ][] = 'mediawiki.ui.button';
-			$modules[ 'styles' ][ 'content' ][] = 'zzz.ext.bootstrap.styles';
-			$modules[ 'styles' ][ 'content' ][] = 'mediawiki.legacy.commonPrint';
-
-			if ( $out->isSyndicated() ) {
-				$modules[ 'styles' ][ 'content' ][] = 'mediawiki.feedlink';
-			}
-		}
-
-		return $modules;
-	}
-
-	/**
 	 * @param OutputPage $out
 	 */
 	public function initPage( OutputPage $out ) {

--- a/src/Components/NavbarHorizontal/Toolbox.php
+++ b/src/Components/NavbarHorizontal/Toolbox.php
@@ -70,21 +70,13 @@ class Toolbox extends Component {
 	 * @throws \MWException
 	 */
 	private function getLinkListItems( $indent = 0 ) {
-		global $wgVersion;
-
 		$this->indent( $indent );
 
 		$skinTemplate = $this->getSkinTemplate();
 
 		$listItems = [];
+		$toolbox = $skinTemplate->get( 'sidebar' )[ 'TOOLBOX' ] ?? array();
 
-		if ( version_compare( $wgVersion, '1.35', '<' ) ) {
-			$toolbox = $skinTemplate->getToolbox();
-		} else if ( isset( $skinTemplate->get( 'sidebar' )[ 'TOOLBOX' ] ) ) {
-			$toolbox = $skinTemplate->get( 'sidebar' )[ 'TOOLBOX' ];
-		} else {
-			$toolbox = array();
-		}
 		// FIXME: Do we need to care of dropdown menus here? E.g. RSS feeds?
 		foreach ( $toolbox as $key => $linkItem ) {
 			if ( isset( $linkItem[ 'class' ] ) ) {

--- a/src/Components/PageTools.php
+++ b/src/Components/PageTools.php
@@ -205,13 +205,8 @@ class PageTools extends Component {
 		}
 
 		// Makes namespace key lowercase
-		if ( version_compare( $wgVersion, '1.36', '<' ) ) {
-			$namespaceKey =
-				MediaWikiServices::getInstance()->getMainConfig()->get( 'ContLang' )->lc( $namespaceKey );
-		} else {
-			$namespaceKey =
-				MediaWikiServices::getInstance()->getContentLanguage()->lc( $namespaceKey );
-		}
+		$namespaceKey =
+			MediaWikiServices::getInstance()->getContentLanguage()->lc( $namespaceKey );
 
 		if ( $namespaceKey === '' ) {
 			return 'main';

--- a/src/Components/PageTools.php
+++ b/src/Components/PageTools.php
@@ -193,8 +193,6 @@ class PageTools extends Component {
 	 * @throws \ConfigException
 	 */
 	public function getNamespaceKey() {
-		global $wgVersion;
-
 		// Gets the subject namespace of this title
 		$title = $this->getSkinTemplate()->getSkin()->getTitle();
 

--- a/src/Components/SearchBar.php
+++ b/src/Components/SearchBar.php
@@ -102,12 +102,6 @@ class SearchBar extends Component {
 			$attributes['placeholder'] = $this->getAttribute( 'placeholder' );
 		}
 
-		// pre-MW 1.35 backward compatibility
-		if ( !method_exists( Skin::class, 'makeSearchInput' ) ) {
-			/* @phan-suppress-next-line PhanAccessMethodProtected */
-			return $this->getSkinTemplate()->makeSearchInput( $attributes ) ?? '';
-		}
-
 		return $this->getSkin()->makeSearchInput( $attributes ) ?? '';
 	}
 

--- a/tests/phpunit/Unit/Components/ComponentTest.php
+++ b/tests/phpunit/Unit/Components/ComponentTest.php
@@ -190,13 +190,7 @@ class ComponentTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getHtml' )
 			->will( $this->returnValue( 'SomeHtml' ) );
 
-		if ( method_exists( '\PHPUnit\Framework\TestCase', 'assertIsString' ) ) {
-			$this->assertIsString( $instance->getClassString() );
-		} else {
-			// @codingStandardsIgnoreStart
-			$this->assertInternalType( 'string', $instance->getClassString() );
-			// @codingStandardsIgnoreEnd
-		}
+		$this->assertIsString( $instance->getClassString() );
 	}
 
 	/**
@@ -329,13 +323,7 @@ class ComponentTest extends \PHPUnit\Framework\TestCase {
 	 * @param string $message
 	 */
 	public function assertValidHTML( $actual, $message = '' ) {
-		if ( method_exists( '\PHPUnit\Framework\TestCase', 'assertIsString' ) ) {
-			$this->assertIsString( $actual, $message );
-		} else {
-			// @codingStandardsIgnoreStart
-			$this->assertInternalType( 'string', $actual, $message );
-			// @codingStandardsIgnoreEnd
-		}
+		$this->assertIsString( $actual, $message );
 	}
 
 }

--- a/tests/phpunit/Unit/Components/MainContentTest.php
+++ b/tests/phpunit/Unit/Components/MainContentTest.php
@@ -57,12 +57,6 @@ class MainContentTest extends GenericComponentTestCase {
 		];
 
 		$instance = new MainContent( $chameleonTemplate );
-		if ( method_exists( '\PHPUnit\Framework\TestCase', 'assertIsString' ) ) {
-			$this->assertIsString( $instance->getHtml() );
-		} else {
-			// @codingStandardsIgnoreStart
-			$this->assertInternalType( 'string', $instance->getHtml() );
-			// @codingStandardsIgnoreEnd
-		}
+		$this->assertIsString( $instance->getHtml() );
 	}
 }


### PR DESCRIPTION
Fixes: #246 

This raises the minimum versions and removes all the explicit workarounds.

I used MW 1.35's official PHP 7.3.19 requirement. Should we stick to that, or just raise it to 7.4 as part of Chameleon 4.0.0?
PHP 7.3's active support ended Dec 2020 and security support ends Dec 2021. If we go with the latter it means Chameleon is technically not supported everywhere MW 1.35 is. If we don't do this now, I assume it will be another major version change later?

There shouldn't currently be any PHP 7.4-only code anywhere, because CI unit tests still worked with 7.1.