### PR TITLE
Fix MW 1.31 regression

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,14 +4,14 @@
 
 Under development.
 
-* Fixes MediaWiki 1.31 regression in Chameleon 3.2
+* Fixes MediaWiki 1.31 compatibility
 * Added `id` attribute to structure components: `Grid`, `Row`, `Cell` and `Container` (thanks @malberts)
 
 ### Chameleon 3.2.1
 
 Released on June 3, 2021.
 
-Warning: This release contains a regression that causes incomaptibility with MediaWiki 1.31.
+Warning: This release contains a regression that causes incompatibility with MediaWiki 1.31.
 
 * Fixed `LangLinks` component PHP notice (thanks @WouterRademaker)
 
@@ -19,7 +19,7 @@ Warning: This release contains a regression that causes incomaptibility with Med
 
 Released on June 2, 2021.
 
-Warning: This release contains a regression that causes incomaptibility with MediaWiki 1.31.
+Warning: This release contains a regression that causes incompatibility with MediaWiki 1.31.
 
 * Improved Echo support in the `PersonalTools` components (thanks @malberts)
 * Added theme support via the new `ChameleonThemeFile` setting (thanks @malberts)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,17 +4,22 @@
 
 Under development.
 
+* Fixes MediaWiki 1.31 regression in Chameleon 3.2
 * Added `id` attribute to structure components: `Grid`, `Row`, `Cell` and `Container` (thanks @malberts)
 
 ### Chameleon 3.2.1
 
 Released on June 3, 2021.
 
+Warning: This release contains a regression that causes incomaptibility with MediaWiki 1.31.
+
 * Fixed `LangLinks` component PHP notice (thanks @WouterRademaker)
 
 ### Chameleon 3.2.0
 
 Released on June 2, 2021.
+
+Warning: This release contains a regression that causes incomaptibility with MediaWiki 1.31.
 
 * Improved Echo support in the `PersonalTools` components (thanks @malberts)
 * Added theme support via the new `ChameleonThemeFile` setting (thanks @malberts)

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -66,8 +66,6 @@ class Chameleon extends SkinTemplate {
 		 * a instantiated class
 		 */
 
-		 global $wgVersion;
-
 		/**
 		 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BeforeInitialize
 		 */
@@ -86,28 +84,6 @@ class Chameleon extends SkinTemplate {
 			$rl->register( 'zzz.ext.bootstrap.styles',
 				$GLOBALS['wgResourceModules']['ext.bootstrap.styles'] );
 		};
-
-		// Add styles for MediaWiki 1.31
-		if ( version_compare( $wgVersion, '1.32', '<') ) {
-			$GLOBALS[ 'wgHooks' ][ 'BeforePageDisplay' ][ ] = function ( OutputPage $out, Skin $skin ) {
-				$moduleStyles = [
-					'mediawiki.skinning.content',
-					'mediawiki.legacy.commonPrint',
-					'mediawiki.ui.button',
-					'zzz.ext.bootstrap.styles'
-				];
-
-				if ( $out->isSyndicated() ) {
-					$moduleStyles[] = 'mediawiki.feedlink';
-				}
-
-				if ( $GLOBALS[ 'egChameleonEnableExternalLinkIcons' ] === true ) {
-					$moduleStyles[] = 'mediawiki.skinning.content.externallinks';
-				}
-
-				$out->addModuleStyles( $moduleStyles );
-			};
-		}
 
 		// set default skin layout
 		if ( DIRECTORY_SEPARATOR === '/' && $GLOBALS[ 'egChameleonLayoutFile' ][0] !== '/' ) {
@@ -153,6 +129,28 @@ class Chameleon extends SkinTemplate {
 	 */
 	public function initPage( OutputPage $out ) {
 		parent::initPage( $out );
+
+		global $wgVersion;
+
+		// Add styles for MediaWiki 1.31
+		if ( version_compare( $wgVersion, '1.32', '<' ) ) {
+			$moduleStyles = [
+				'mediawiki.skinning.content',
+				'mediawiki.legacy.commonPrint',
+				'mediawiki.ui.button',
+				'zzz.ext.bootstrap.styles'
+			];
+
+			if ( $out->isSyndicated() ) {
+				$moduleStyles[] = 'mediawiki.feedlink';
+			}
+
+			if ( $GLOBALS[ 'egChameleonEnableExternalLinkIcons' ] === true ) {
+				$moduleStyles[] = 'mediawiki.skinning.content.externallinks';
+			}
+
+			$out->addModuleStyles( $moduleStyles );
+		}
 
 		// Enable responsive behaviour on mobile browsers
 		$out->addMeta( 'viewport', 'width=device-width, initial-scale=1, shrink-to-fit=no' );


### PR DESCRIPTION
Fixes: #267 

* Fixes the MW 1.31 regression introduced by https://github.com/ProfessionalWiki/chameleon/commit/40a60c9aaa9b1afc38a4dc88dbdd2bec6f232f58
* Replace the deprecated `setupSkinUserCss` with `initPage`

Not sure if MW 1.32 - 1.34 worked correctly with https://github.com/ProfessionalWiki/chameleon/commit/40a60c9aaa9b1afc38a4dc88dbdd2bec6f232f58 (i.e. Chameleon 3.2.0+), but since all those versions are obsolete I'm not going to test them.