### PR TITLE
Improve Echo icon styling for MW 1.31

### DIFF
--- a/resources/styles/_extensionfixes.scss
+++ b/resources/styles/_extensionfixes.scss
@@ -42,9 +42,15 @@
 		padding: 0px;
 	}
 
-	#pt-notifications-alert .mw-echo-notifications-badge,
-	#pt-notifications-notice .mw-echo-notifications-badge {
+	#pt-notifications-alert .mw-echo-notifications-badge.oo-ui-icon-bell,
+	#pt-notifications-notice .mw-echo-notifications-badge.oo-ui-icon-tray {
 		top: 0px;
+	}
+
+	// MW 1.31
+	#pt-notifications-alert .mw-echo-notifications-badge:not(.oo-ui-icon-bell):before,
+	#pt-notifications-notice .mw-echo-notifications-badge:not(.oo-ui-icon-tray):before {
+		top: 1005px;
 	}
 }
 


### PR DESCRIPTION
MW 1.31 Echo styling was different compared to 1.35. This applies the 1.35 fix to 1.31.