### PR TITLE
Add PersonalTools user name display

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -758,7 +758,7 @@ applicable.
   If set the newtalk notifier will not be shown.
 
   This attribute has no effect when used inside the
-  [NavbarHorizontal](#component-navbar-horizontal) component.
+  [NavbarHorizontal](#component-navbarhorizontal) component.
   
   This attribute was introduced to keep backwards compatibility. If the
   PersonalTools component is used, it is recommended to always set this
@@ -774,6 +774,18 @@ applicable.
   Use `icons` to render Echo links as icons that trigger popups (default Echo behavior).
   When the parent is `NavbarHorizontal` the Echo icons will be displayed next to the dropdown.
   Use `links` to render Echo links as normal links without popups.
+
+* `showUserName`:
+  * Since Chameleon 3.4.0
+  * Allowed values: Boolean (`yes`|`no`)
+  * Default: `no`
+  * Optional.
+
+  If set the logged in user's real name (if available) or username will be shown next to the
+  dropdown icon.
+
+  This attribute applies only when used inside the
+  [NavbarHorizontal](#component-navbarhorizontal) component.
 
 #### Allowed Parent Elements:
 * [Structure](#structure)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
 
 Under development.
 
+* Added `PersonalTools` user name display via the new `showUserName` attribute (thanks @malberts)
 * Fixed `Toolbox` component PHP notice (thanks @WouterRademaker)
 * Translation updates for system messages (thanks @translatewiki and its translator community)
 

--- a/layouts/clean.xml
+++ b/layouts/clean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.0/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 This file is part of the MediaWiki skin Chameleon.
 
 @copyright 2013 - 2021, Stephan Gambke
@@ -23,7 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 @since 1.1
 @ingroup Skins
 -->
-<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng">
+<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng">
 
 	<component type="NavbarHorizontal" >
 		<modification type="ShowOnlyFor" permission="edit"/>

--- a/layouts/fixedhead.xml
+++ b/layouts/fixedhead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.0/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 This file is part of the MediaWiki skin Chameleon.
 
 @copyright 2013 - 2021, Stephan Gambke
@@ -23,7 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 @since 1.0
 @ingroup Skins
 -->
-<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng">
+<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng">
 
 	<component type="NavbarHorizontal">
 		<modification type="Sticky"/>

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -25,13 +25,13 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 <grammar
 		xmlns="http://relaxng.org/ns/structure/1.0"
 		xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-		ns="https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng"
+		ns="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng"
 		datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
 >
 
 	<a:documentation>
 		Schema for Chameleon layout files
-		Version 3.1
+		Version 3.2
 		Copyright 2013 - 2021, Stephan Gambke
 		GNU General Public License, version 3 (or any later version)
 	</a:documentation>
@@ -312,6 +312,12 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 					<value>icons</value>
 					<value>links</value>
 				</choice>
+			</attribute>
+		</optional>
+
+		<optional>
+			<attribute name="showUserName" a:defaultValue="no">
+				<ref name="BoolValues"/>
 			</attribute>
 		</optional>
 	</define>

--- a/layouts/navhead.xml
+++ b/layouts/navhead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.0/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 This file is part of the MediaWiki skin Chameleon.
 
 @copyright 2013 - 2021, Stephan Gambke
@@ -23,7 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 @since 1.0
 @ingroup Skins
 -->
-<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng">
+<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng">
 	<component type="NavbarHorizontal">
 		<component type="Logo" position="head"/>
 		<component type="NavMenu" flatten="navigation" />

--- a/layouts/standard.xml
+++ b/layouts/standard.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.0/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 This file is part of the MediaWiki skin Chameleon.
 
 @copyright 2013 - 2021, Stephan Gambke
@@ -23,7 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 @since 1.0
 @ingroup Skins
 -->
-<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng">
+<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng">
 	<grid class="flex-fill">
 		<row>
 			<cell class="flex-grow-0">

--- a/layouts/stickyhead.xml
+++ b/layouts/stickyhead.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.0/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 This file is part of the MediaWiki skin Chameleon.
 
 @copyright 2013 - 2021, Stephan Gambke
@@ -23,7 +23,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 @since 1.0
 @ingroup Skins
 -->
-<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng">
+<structure xmlns="https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng">
 
 	<component type="NavbarHorizontal" class="small bg-darker">
 		<component type="Menu" message="secondary-menu"/>

--- a/maintenance/validateLayout.php
+++ b/maintenance/validateLayout.php
@@ -79,7 +79,7 @@ function validateFile( $filename ) {
 	$xml = new DOMDocument();
 	$xml->load( $filename );
 
-	if ( !$xml->relaxNGValidate( 'https://ProfessionalWiki.github.io/chameleon/schema/3.1/layout.rng' ) ) {
+	if ( !$xml->relaxNGValidate( 'https://ProfessionalWiki.github.io/chameleon/schema/3.2/layout.rng' ) ) {
 		libxml_display_errors();
 	} else {
 		print "Ok!\n";

--- a/src/Components/NavbarHorizontal/PersonalTools.php
+++ b/src/Components/NavbarHorizontal/PersonalTools.php
@@ -45,6 +45,7 @@ class PersonalTools extends Component {
 	private const ATTR_SHOW_ECHO = 'showEcho';
 	private const SHOW_ECHO_ICONS = 'icons';
 	private const SHOW_ECHO_LINKS = 'links';
+	private const ATTR_SHOW_USER_NAME = 'showUserName';
 
 	/**
 	 * @return String
@@ -91,6 +92,22 @@ class PersonalTools extends Component {
 		$this->indent( -1 );
 
 		return $newtalkNotifier;
+	}
+
+	/**
+	 * @return string
+	 * @throws \FatalError
+	 * @throws \MWException
+	 */
+	protected function getUserName() {
+		if ( filter_var( $this->getAttribute( self::ATTR_SHOW_USER_NAME ), FILTER_VALIDATE_BOOLEAN ) ) {
+			$user = $this->getSkinTemplate()->getSkin()->getUser();
+			if ( $user->isLoggedIn() ) {
+				$username = !empty( $user->getRealName() ) ? $user->getRealName() : $user->getName();
+				return '<span class="user-name">' . htmlspecialchars( $username ) . '</span>';
+			}
+		}
+		return '';
 	}
 
 	/**
@@ -190,7 +207,8 @@ class PersonalTools extends Component {
 
 		$dropdownToggle = IdRegistry::getRegistry()->element( 'a', [ 'class' => $toolsClass,
 			'href' => '#', 'data-toggle' => 'dropdown', 'data-boundary' => 'viewport',
-			'title' => $toolsLinkText ], $this->getNewtalkNotifier(), $this->indent() );
+			'title' => $toolsLinkText ], $this->getNewtalkNotifier() . $this->getUserName(),
+			$this->indent() );
 
 		$this->indent( -1 );
 


### PR DESCRIPTION
Add `PersonalTools` attribute to allow showing the logged in user's real name or username next to the dropdown.

User with real name:
![image](https://user-images.githubusercontent.com/1428594/127745764-8009dcac-741e-4843-bf1f-7092e6385ce6.png)

User without real name:
![image](https://user-images.githubusercontent.com/1428594/127745789-54f64a68-36c4-4119-b804-387da8213809.png)

Default behavior:
![image](https://user-images.githubusercontent.com/1428594/127745848-f0745802-fb25-4bb1-a473-d237a2e03c41.png)
