### PR TITLE
Add TOC feature for MW 1.37

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -43,7 +43,7 @@
 	"ResourceModules": {
 		"skins.chameleon": {
 			"class": "ResourceLoaderSkinModule",
-			"features": [ "elements", "content", "legacy" ],
+			"features": [ "elements", "content", "legacy", "toc" ],
 			"targets": [
 				"desktop",
 				"mobile"


### PR DESCRIPTION
TOC styling was broken in 1.37.

Before:
![Screenshot_20220118_112321](https://user-images.githubusercontent.com/1428594/149908472-51c44444-e861-4c99-be47-918698b5d9d6.png)

After:
![Screenshot_20220118_112409](https://user-images.githubusercontent.com/1428594/149908488-c124cbb0-dfa3-46f2-8f09-82fa41342f5d.png)


This does not affect MW 1.35's styling.