### PR TITLE
Update Grid.php to support container size with mode attribute

### DIFF
--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -80,6 +80,11 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 				<attribute name="mode" a:defaultValue="fixedwidth">
 					<choice>
 						<value>fixedwidth</value>
+						<value>sm</value>
+						<value>md</value>
+						<value>lg</value>
+						<value>xl</value>
+						<value>xxl</value>
 						<value>fluid</value>
 					</choice>
 				</attribute>

--- a/src/Components/Grid.php
+++ b/src/Components/Grid.php
@@ -39,7 +39,22 @@ class Grid extends Container {
 
 	private const ATTR_MODE = 'mode';
 	private const MODE_FIXEDWIDTH = 'fixedwidth';
+	private const MODE_SM = 'sm';
+	private const MODE_MD = 'md';
+	private const MODE_LG = 'lg';
+	private const MODE_XL = 'xl';
+	private const MODE_XXL = 'xxl';
 	private const MODE_FLUID = 'fluid';
+
+	private const VALID_MODES = [
+		self::MODE_FIXEDWIDTH,
+		self::MODE_SM,
+		self::MODE_MD,
+		self::MODE_LG,
+		self::MODE_XL,
+		self::MODE_XXL,
+		self::MODE_FLUID,
+	];
 
 	/**
 	 * @param ChameleonTemplate $template
@@ -48,17 +63,13 @@ class Grid extends Container {
 	 */
 	public function __construct( ChameleonTemplate $template, \DOMElement $domElement = null,
 		$indent = 0 ) {
-		if ( $this->isFluidMode() ) {
-			$this->addClasses( 'container-fluid' );
-		} else {
-			$this->addClasses( 'container' );
-		}
-		
 		parent::__construct( $template, $domElement, $indent );
-	}
 
-	protected function isFluidMode() {
-		return $this->getAttribute( self::ATTR_MODE, self::MODE_FIXEDWIDTH ) === self::MODE_FLUID;
+		$mode = $this->getAttribute( self::ATTR_MODE, self::MODE_FIXEDWIDTH );
+		if( $mode === self::MODE_FIXEDWIDTH || !in_array( $mode, self::VALID_MODES ) ) {
+			$this->addClasses( 'container' );
+		} else {
+			$this->addClasses( 'container-' . $mode );
+		}
 	}
-
 }

--- a/src/Components/Grid.php
+++ b/src/Components/Grid.php
@@ -53,7 +53,7 @@ class Grid extends Container {
 		self::MODE_LG,
 		self::MODE_XL,
 		self::MODE_XXL,
-		self::MODE_FLUID,
+		self::MODE_FLUID
 	];
 
 	/**

--- a/src/Components/Grid.php
+++ b/src/Components/Grid.php
@@ -48,13 +48,13 @@ class Grid extends Container {
 	 */
 	public function __construct( ChameleonTemplate $template, \DOMElement $domElement = null,
 		$indent = 0 ) {
-		parent::__construct( $template, $domElement, $indent );
-
 		if ( $this->isFluidMode() ) {
 			$this->addClasses( 'container-fluid' );
 		} else {
 			$this->addClasses( 'container' );
 		}
+		
+		parent::__construct( $template, $domElement, $indent );
 	}
 
 	protected function isFluidMode() {


### PR DESCRIPTION
I think the container or container-fluid class should be added before calling the parent constructor to allow explicitly defined classes in the layout to override the container class (e.g. with something like container-md).