### PR TITLE
Fix abs() issue with Bootstrap 4.6.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,7 @@ Under development.
 
 * Added support for responsive containers on the `Grid` component (thanks @chrisrishel)
 * Fixed Mediawiki 1.38 hard deprecations (thanks @malberts)
+* Fixed Bootstrap 4.6.1 compatibility (thanks @malberts)
 
 ### Chameleon 4.0.1
 

--- a/resources/styles/_functions.scss
+++ b/resources/styles/_functions.scss
@@ -11,7 +11,7 @@
 //
 // @param $value a value in rem or px
 // @return unitless px value
-@function abs( $value ) {
+@function rem-to-px( $value ) {
 	@if (type-of($value) == "number") and ($value != 0) {
 
 		$unit: unit($value);

--- a/resources/styles/_mixins.scss
+++ b/resources/styles/_mixins.scss
@@ -53,8 +53,8 @@
 // top vertically (or as far down as possible given the diameter)
 @mixin bullet( $color: $list-bullet-color, $width: $list-bullet-size, $height: $font-size-base ) {
 
-	$width: abs($width);
-	$height: abs($height);
+	$width: rem-to-px($width);
+	$height: rem-to-px($height);
 	list-style: outside disc url("data:image/svg+xml;charset=UTF-8,<svg width='#{$width}' height='#{$height}' version='1.1' xmlns='http://www.w3.org/2000/svg'><circle cx='#{$width/2}' cy='#{min($height - min($width, $height)/2, 0.65*$height)}' r='#{min($width, $height)/2}' fill='#{$color}'/></svg>");
 	// IE hack: IE < 9 does not properly work with SVGs. Serve them some fallback PNG.
 	list-style-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAJCAYAAAARml2dAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAN1wAADdcBQiibeAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAABUSURBVAiZdY4xDsAgFELB2J0DdnbwQI5OHvDfgC62SY0yvhAetI1dWEq5JN0kKwDYbhEx8oT9a5JdEtLb/M2QNW0FAJLttkLbLUfEkIRVztPdo+MBm8UkW9Zxc20AAAAASUVORK5CYII=")#{"\9"};


### PR DESCRIPTION
Chameleon previously defined an `abs()` function which overwrites the SASS core `abs()` (https://sass-lang.com/documentation/modules/math#abs).
This caused a compilation issue with Bootstrap 4.6.1 because it expected to use the core `abs()`:
https://github.com/ProfessionalWiki/Bootstrap/blob/524415029465d560e78e29eb50e2cdd0a8e25ea3/resources/bootstrap/scss/vendor/_rfs.scss#L54-L55