### PR TITLE
Bootstrap tweak to prevent ugly linebreaks within navbar links

### DIFF
--- a/resources/styles/_fixes.scss
+++ b/resources/styles/_fixes.scss
@@ -58,3 +58,8 @@
 .alert p:last-child {
 	margin-bottom: 0;
 }
+
+// prevent ugly linebreaks within navbar links
+.navbar-nav .nav-link {
+	white-space: nowrap;
+}


### PR DESCRIPTION
This one-liner in _fixes.scss adds a "nowrap" to nav-link elements, to prevent weird linebreaks from showing up if a navbar link contains whitespace, fattening the navbar and throwing off vertical alignment.

(Bootstrap already applies nowrap to dropdown-items.)