### PR TITLE
Add option to display username-only in PersonalTools (fixes #343)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -938,12 +938,15 @@ applicable.
 
 * `showUserName`:
   * Since Chameleon 3.4.0
-  * Allowed values: Boolean (`yes`|`no`)
-  * Default: `no`
+  * Allowed values: String (`none`|`username-only`|`try-realname`)
+  * Default: `none`
   * Optional.
 
-  If set the logged in user's real name (if available) or username will be shown next to the
-  dropdown icon.
+  If set to `username-only`, the logged-in user's username will be shown next to the dropdown icon
+  (since Chameleon 4.2.0).
+
+  If set to `try-realname`, the logged-in user's real name will be shown next to the dropdown icon,
+  if it is non-empty. If the real name is empty, the user's username will be shown.
 
   This attribute applies only when used inside the
   [NavbarHorizontal](#component-navbarhorizontal) component.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,7 @@ Under development.
 
 * Extracted `Indicators`, `ContentHeader`, `ContentBody` and `CategoryLinks` sub-components from `MainContent` component (thanks @gesinn-it-wam)
 * Fixed navbar whitespace issue (thanks @mdoggydog)
+* For `PersonalTools` component used within `NavbarHorizontal`, changed the set of allowed values to `none`, `try-realname`, and `username-only` (new).  `no` and `yes` are deprecated but still accepted for backwards compatibility. (thanks @mdoggydog)
 
 ### Chameleon 4.1.0
 

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -385,8 +385,14 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 		</optional>
 
 		<optional>
-			<attribute name="showUserName" a:defaultValue="no">
-				<ref name="BoolValues"/>
+			<attribute name="showUserName" a:defaultValue="none">
+				<choice>
+					<value>none</value>
+					<value>try-realname</value>
+					<value>username-only</value>
+					<value>no</value>
+					<value>yes</value>
+				</choice>
 			</attribute>
 		</optional>
 	</define>

--- a/src/Components/NavbarHorizontal/PersonalTools.php
+++ b/src/Components/NavbarHorizontal/PersonalTools.php
@@ -46,6 +46,12 @@ class PersonalTools extends Component {
 	private const SHOW_ECHO_ICONS = 'icons';
 	private const SHOW_ECHO_LINKS = 'links';
 	private const ATTR_SHOW_USER_NAME = 'showUserName';
+	private const SHOW_USER_NAME_NONE = 'none';
+	private const SHOW_USER_NAME_TRY_REALNAME = 'try-realname';
+	private const SHOW_USER_NAME_USERNAME_ONLY = 'username-only';
+	# Boolean values for showUserName deprecated since Chameleon 4.2.0:
+	private const SHOW_USER_NAME_NO = 'no';
+	private const SHOW_USER_NAME_YES = 'yes';
 
 	/**
 	 * @return String
@@ -100,11 +106,15 @@ class PersonalTools extends Component {
 	 * @throws \MWException
 	 */
 	protected function getUserName() {
-		if ( filter_var( $this->getAttribute( self::ATTR_SHOW_USER_NAME ), FILTER_VALIDATE_BOOLEAN ) ) {
-			$user = $this->getSkinTemplate()->getSkin()->getUser();
-			if ( $user->isRegistered() ) {
+		$user = $this->getSkinTemplate()->getSkin()->getUser();
+		if ( $user->isRegistered() ) {
+			$showUserName = $this->getAttribute( self::ATTR_SHOW_USER_NAME );
+			if ( ( $showUserName == self::SHOW_USER_NAME_TRY_REALNAME ) ||
+				 ( $showUserName == self::SHOW_USER_NAME_YES ) ) {
 				$username = !empty( $user->getRealName() ) ? $user->getRealName() : $user->getName();
 				return '<span class="user-name">' . htmlspecialchars( $username ) . '</span>';
+			} elseif ( $showUserName == self::SHOW_USER_NAME_USERNAME_ONLY ) {
+				return '<span class="user-name">' . htmlspecialchars( $user->getName() ) . '</span>';
 			}
 		}
 		return '';


### PR DESCRIPTION
This adds a `username-only` option to the `showUserName` attribute in the `PersonalTools` component (when used within the `NavbarHorizontal`), to show *only* the username for logged-in users.  The prior `yes` option has been renamed to `try-realname` for clarity, and the `no` option has been renamed to `none` (the new default).

For backwards compatibility, `no` and `yes` are still accepted, but a deprecation note has been added to the code.