### PR TITLE
Add classes to NavMenu elements based on section/menu-id

### DIFF
--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -150,12 +150,19 @@ class NavMenu extends Component {
 	 * @throws \MWException
 	 */
 	protected function buildDropdownMenuStub( $menuDescription ) {
+		$menuId = $menuDescription['id'];
+
 		return $this->indent() . \Html::rawElement( 'div',
 				[
-					'class' => 'nav-item',
-					'title' => Linker::titleAttrib( $menuDescription['id'] )
+					'class' => 'nav-item ' . $menuId . '-dropdown',
+					'title' => Linker::titleAttrib( $menuId )
 				],
-				'<a href="#" class="nav-link">' . htmlspecialchars( $menuDescription['header'] ) . '</a>'
+				\Html::rawElement( 'a',
+					[
+						'href' => '#',
+						'class' => 'nav-link ' . $menuId . '-toggle',
+					],
+					htmlspecialchars( $menuDescription['header'] ) )
 			);
 	}
 
@@ -166,24 +173,32 @@ class NavMenu extends Component {
 	 * @throws \MWException
 	 */
 	protected function buildDropdownOpeningTags( $menuDescription ) {
+		$menuId = $menuDescription['id'];
+
 		// open list item containing the dropdown
 		$ret = $this->indent() . \Html::openElement( 'div',
 				[
-					'class' => 'nav-item dropdown',
-					'title' => Linker::titleAttrib( $menuDescription['id'] ),
+					'class' => 'nav-item dropdown ' . $menuId . '-dropdown',
+					'title' => Linker::titleAttrib( $menuId ),
 				] );
 
 		// add the dropdown toggle
 		$ret .= $this->indent( 1 ) .
-			'<a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" data-boundary="viewport">' .
-			htmlspecialchars( $menuDescription['header'] ) . '</a>';
+			\Html::rawElement( 'a',
+				[
+					'href' => '#',
+					'class' => 'nav-link dropdown-toggle ' . $menuId . '-toggle',
+					'data-toggle' => 'dropdown',
+					'data-boundary' => 'viewport',
+				],
+				htmlspecialchars( $menuDescription['header'] ) );
 
 		// open list of dropdown menu items
 		$ret .=
 			$this->indent() . \Html::openElement( 'div',
 				[
-					'class' => 'dropdown-menu ' . $menuDescription['id'],
-					'id'    => IdRegistry::getRegistry()->getId( $menuDescription['id'] ),
+					'class' => 'dropdown-menu ' . $menuId,
+					'id'    => IdRegistry::getRegistry()->getId( $menuId ),
 				]
 			);
 		return $ret;


### PR DESCRIPTION
This adds section-specific classes to the links/toggles created by `NavMenu`, following the model of `Toolbox`.  This allows for more CSS customizations, e.g., adding icons to NavMenu dropdown-toggles in the navbar.

For a section with `menuid` as its id:
 - The wrapper `<div>` gets additional class `menuid-dropdown`.
 - The toggle button `<a>` gets additional class `menuid-toggle`.

The existing code already assigns class `menuid` to the `<div>` containing the menu items (for sections that have a non-empty list of items).  This behavior has not been changed.

For example, the `navigation` section has id `p-navigation`, so:
 - its wrapper `<div>` now gets class `p-navigation-dropdown`;
 - the toggle button now gets class `p-navigation-toggle`;
 - the menu already/still has class `p-navigation`.