### PR TITLE
Provide a 'title' attribute to Toolbox's dropdown-toggle button

### DIFF
--- a/src/Components/NavbarHorizontal/Toolbox.php
+++ b/src/Components/NavbarHorizontal/Toolbox.php
@@ -27,6 +27,7 @@
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
 use Hooks;
+use Linker;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\IdRegistry;
 
@@ -108,7 +109,8 @@ class Toolbox extends Component {
 		$trigger = $this->indent( 1 ) . IdRegistry::getRegistry()->element(
 				'a',
 				[ 'href' => '#', 'class' => 'nav-link dropdown-toggle p-tb-toggle',
-					'data-toggle' => 'dropdown', 'data-boundary' => 'viewport' ],
+                  'data-toggle' => 'dropdown', 'data-boundary' => 'viewport',
+                  'title' => Linker::titleAttrib( 'p-tb' ), ],
 				$this->getSkinTemplate()->getMsg( $labelMsg )->escaped()
 			);
 


### PR DESCRIPTION
This commit adds the machinery for providing a `title` attribute to the dropdown toggle `<a>` element of the `Toolbox` menu.  Following the usual MediaWiki scheme for tooltips, the `title` attribute will be populated with the contents of `MediaWiki:Tooltip-p-tb` (if that page has been created on the wiki).