### PR TITLE
Move 'title' attribute of NavMenu toggles to the <a> elements

### DIFF
--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -155,12 +155,12 @@ class NavMenu extends Component {
 		return $this->indent() . \Html::rawElement( 'div',
 				[
 					'class' => 'nav-item ' . $menuId . '-dropdown',
-					'title' => Linker::titleAttrib( $menuId )
 				],
 				\Html::rawElement( 'a',
 					[
 						'href' => '#',
 						'class' => 'nav-link ' . $menuId . '-toggle',
+						'title' => Linker::titleAttrib( $menuId ),
 					],
 					htmlspecialchars( $menuDescription['header'] ) )
 			);
@@ -179,7 +179,6 @@ class NavMenu extends Component {
 		$ret = $this->indent() . \Html::openElement( 'div',
 				[
 					'class' => 'nav-item dropdown ' . $menuId . '-dropdown',
-					'title' => Linker::titleAttrib( $menuId ),
 				] );
 
 		// add the dropdown toggle
@@ -190,6 +189,7 @@ class NavMenu extends Component {
 					'class' => 'nav-link dropdown-toggle ' . $menuId . '-toggle',
 					'data-toggle' => 'dropdown',
 					'data-boundary' => 'viewport',
+					'title' => Linker::titleAttrib( $menuId ),
 				],
 				htmlspecialchars( $menuDescription['header'] ) );
 


### PR DESCRIPTION
Currently, the `title` attribute on a NavMenu section/item is placed on the top-level wrapper `<div>` element, instead of the dropdown-toggle's `<a>` element.  Everywhere else, `title` attributes are placed directly on the `<a>` element of the button/item/link.

Since the top-level wrapper `<div>` encompasses the menu as well as the toggle, any items in the menu that do not have their own explicit `title` attribute will inherit the top-level title.  In other words, menu items that should not have tooltips will get the same tooltip as the dropdown-toggle.

This commit moves the `title` attribute in NavMenu off the top-level `<div>` and onto the toggle `<a>` element.