### PR TITLE
Tweak CSS to center-align navbar items in minor-axis direction

### DIFF
--- a/resources/styles/_fixes.scss
+++ b/resources/styles/_fixes.scss
@@ -59,7 +59,12 @@
 	margin-bottom: 0;
 }
 
-// prevent ugly linebreaks within navbar links
-.navbar-nav .nav-link {
-	white-space: nowrap;
+.navbar-nav {
+	// in minor axis direction, center-align navbar items
+	align-items: center;
+
+	.nav-link {
+		// prevent ugly linebreaks within navbar links
+		white-space: nowrap;
+	}
 }


### PR DESCRIPTION
In other words:
 * When navbar items are laid out horizontally (wide browser window), align them so they are vertically centered.
 * When navbar items are laid out vertically (collapsible panel), align them so they are horizontally centered.
