### PR TITLE
Tweak CSS to fix grouping of "right" items when navbar is collapsed

### DIFF
--- a/resources/styles/Components/NavbarHorizontal.scss
+++ b/resources/styles/Components/NavbarHorizontal.scss
@@ -59,8 +59,6 @@
 			@extend .ml-#{$cmln-navbar-horizontal-collapse-point}-auto;
 			@extend .mt-#{$cmln-navbar-horizontal-collapse-point}-0;
 			@extend .mt-4;
-			@extend .flex-row;
-			@extend .justify-content-center;
 		}
 
 		.dropdown-menu {


### PR DESCRIPTION
It is not clear what the `.flex-row` on `.navbar-nav.right` elements was intended to accomplish, but the effect that it has is that, when the navbar is collapsed and switches to a vertical layout, all the right-grouped navbar items are jammed together into a single row (instead of switching to a vertical/column layout like the non-right- -grouped items).  Removing the `.flex-row` fixes that.

This commit also removes the `.justify-content-center`, which does not seem to have any effect at all on any layout/orientation/screen. (Since the `.navbar-nav.right` wrapper is always squeezed to the right, there is no free space into which its children can be centered.)

For what it's worth, this commit does leave the `.mt-4` in place; it does not seem to have any effect in the horizontal layout, and in the collapsed/vertical layout it appears to introduce a gap between the "left" grouped (top) items and the "right" grouped (bottom) items.

## Before this commit:
![screenshot-navbar-right-forced-row](https://user-images.githubusercontent.com/53354851/194202166-500ad0de-3b47-4069-8662-9709bbaaeb77.png)

## After this commit:
(...and, after #353 so that everything is vertically centered, too)
![screenshot-navbar-right-not-forced-row](https://user-images.githubusercontent.com/53354851/194202169-e17c27c5-5ad6-400e-bdc3-0bb0fce22b82.png)


