### PR TITLE
Add a hook for customizing the PersonalTools toggle <a> inner html

### DIFF
--- a/src/Components/NavbarHorizontal/PersonalTools.php
+++ b/src/Components/NavbarHorizontal/PersonalTools.php
@@ -210,14 +210,20 @@ class PersonalTools extends Component {
 
 		}
 
+		// TODO Rename '...LinkText' to '...LinkTitle' in both the hook and variable.
 		Hooks::run( 'ChameleonNavbarHorizontalPersonalToolsLinkText', [ &$toolsLinkText,
 			$this->getSkin() ] );
+
+		$newtalkNotifierHtml = $this->getNewtalkNotifier();
+		$userNameHtml = $this->getUserName();
+		Hooks::run( 'ChameleonNavbarHorizontalPersonalToolsLinkInnerHtml',
+			[ &$newtalkNotifierHtml, &$userNameHtml, $this ] );
 
 		$this->indent( 1 );
 
 		$dropdownToggle = IdRegistry::getRegistry()->element( 'a', [ 'class' => $toolsClass,
 			'href' => '#', 'data-toggle' => 'dropdown', 'data-boundary' => 'viewport',
-			'title' => $toolsLinkText ], $this->getNewtalkNotifier() . $this->getUserName(),
+			'title' => $toolsLinkText ], $newtalkNotifierHtml . $userNameHtml,
 			$this->indent() );
 
 		$this->indent( -1 );


### PR DESCRIPTION
This commit adds a `ChameleonNavbarHorizontalPersonalToolsLinkInnerHtml` hook which can be used to completely customize the inner html of the dropdown toggle link of `PersonalTools`.

This hook will be passed three parameters:
 * `$newtalkNotifierHtml` (by reference)
 * `$userNameHtml` (by reference)
 * the `PersonalTools` object

The first two parameters are strings bearing the values computed by the PersonalTools component (according to its configuration, etc), which the hook function may modify (or leave alone).

After the hook function is complete, the values of `$newtalkNotifierHtml` and `$userNameHtml` will be concatenated (in that order) to yield the raw html content of the dropdown toggle's `<a>` element.