### PR TITLE
Add option to PersonalTools to show lone menu items directly in navbar

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -951,6 +951,22 @@ applicable.
   This attribute applies only when used inside the
   [NavbarHorizontal](#component-navbarhorizontal) component.
 
+* `promoteLoneItems`:
+  * Since Chameleon 4.2.0
+  * Allowed values: String
+  * Default: -
+  * Optional.
+
+  A semicolon-separated list of menu items that are candidates for promotion
+  to the navbar.  If the personal tools menu contains a single, lone item,
+  and if that item is in this list, then that menu item will be rendered
+  in the navbar directly, instead of the dropdown toggle and single-item menu.
+
+  This is particularly useful for the `"login"` item in semi-private wikis.
+
+  This attribute applies only when used inside the
+  [NavbarHorizontal](#component-navbarhorizontal) component.
+
 #### Allowed Parent Elements:
 * [Structure](#structure)
 * [Cell](#cell)

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -395,6 +395,12 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 				</choice>
 			</attribute>
 		</optional>
+
+		<optional>
+			<attribute name="promoteLoneItems">
+				<data type="string"/>
+			</attribute>
+		</optional>
 	</define>
 
 	<define name="Component" combine="choice">


### PR DESCRIPTION
This commit adds a `promoteLoneItems` parameter to the `PersonalTools` component.  If there is only one personal tool, and its name is in the parameter, then the link for that tool will be rendered directly in the navbar (instead of in a dropdown menu).

A prime use of this parameter is for a semi-private wiki, where a logged-out user only has the `login` tool available.  With this parameter, the login button can be directly rendered (and thus, clicked) in the navbar, instead of being hidden in a menu activated by a dropdown toggle.