### PR TITLE
Add options to NavMenu to include/exclude specific sections.

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -761,6 +761,28 @@ Using the message _MediaWiki:Secondary-menu_:
   _MediaWiki:skin-chameleon-navmenu-flatten_ instead. If both the message and
   this attribute are found, the message takes precedence.
 
+* `include`
+  * Allowed values: String
+  * Default: -
+  * Optional.
+
+  A semicolon-separated list of section names that are to be included exclusively;
+  i.e., if this parameter is supplied, then only the sections in this list will be
+  rendered.
+
+* `exclude`
+  * Allowed values: String
+  * Default: -
+  * Optional.
+
+  A semicolon-separated list of section names that are to be excluded;
+  i.e., if this parameter is supplied, then the sections in this list will not
+  be rendered.
+
+  `exclude` takes priority over `include`.  It does not make much sense to use
+  both attributes in the same `NavMenu` instance, but it can make sense to use
+  them separately in complementary instances.
+
 #### Allowed Parent Elements:
 * [Structure](#structure)
 * [Cell](#cell)

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -314,6 +314,17 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 			</attribute>
 		</optional>
 
+		<optional>
+			<attribute name="include">
+				<data type="string"/>
+			</attribute>
+		</optional>
+
+		<optional>
+			<attribute name="exclude">
+				<data type="string"/>
+			</attribute>
+		</optional>
 	</define>
 
 	<define name="Component" combine="choice">

--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -39,6 +39,9 @@ use Skins\Chameleon\IdRegistry;
  */
 class NavMenu extends Component {
 
+	private const ATTR_INCLUDE = 'include';
+	private const ATTR_EXCLUDE = 'exclude';
+
 	/**
 	 * Builds the HTML code for this component
 	 *
@@ -55,6 +58,26 @@ class NavMenu extends Component {
 				'languages' => false,
 			]
 		);
+
+		$include = $this->getAttribute( self::ATTR_INCLUDE, false );
+		if ( $include !== false ) {
+			$sidebar = array_intersect_key(
+				$sidebar,
+				// Split on ';', trim whitespace, remove empty strings,
+				// and shove resulting tokens into an arrays as keys.
+				array_fill_keys( preg_split('/\s*;+\s*/', $include,
+						NULL, PREG_SPLIT_NO_EMPTY ), true ) );
+		}
+
+		$exclude = $this->getAttribute( self::ATTR_EXCLUDE, false );
+		if ( $exclude !== false ) {
+			$sidebar = array_diff_key(
+				$sidebar,
+				// Split on ';', trim whitespace, remove empty strings,
+				// and shove resulting tokens into an arrays as keys.
+				array_fill_keys( preg_split('/\s*;+\s*/', $exclude,
+						NULL, PREG_SPLIT_NO_EMPTY ), true ) );
+		}
 
 		$flatten = $this->getMenusToBeFlattened();
 


### PR DESCRIPTION
This commit adds new `include` and `exclude` attributes to the `NavMenu` component.  Both are intended to hold semicolon-separated lists of menu section names.  If neither is specified, the behavior is unchanged from the current behavior.  If `include` is provided, only the specified sections from the sidebar are processed.  If `exclude` is provided, the specified sections are skipped.

These options are complementary, and allow one to locate different menu sections in different `NavMenu` instances, e.g., in different locations on the page.