### PR TITLE
Replace deprecated test method

### DIFF
--- a/tests/phpunit/Unit/Components/FooterIconsTest.php
+++ b/tests/phpunit/Unit/Components/FooterIconsTest.php
@@ -57,12 +57,7 @@ class FooterIconsTest extends GenericComponentTestCase {
 				[ $this->equalTo( 'icon3' ) ],
 				[ $this->equalTo( 'icon4' ) ]
 			)
-			->willReturnOnConsecutiveCalls(
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' )
-			);
+			->willReturn( $this->returnValue( 'SomeHTML' ) );
 
 		$chameleonTemplate->expects( $this->any() )
 			->method( 'getFooterIconsWithImage' )

--- a/tests/phpunit/Unit/Components/FooterIconsTest.php
+++ b/tests/phpunit/Unit/Components/FooterIconsTest.php
@@ -49,25 +49,20 @@ class FooterIconsTest extends GenericComponentTestCase {
 
 		$skin = $chameleonTemplate->getSkin();
 
-		$skin->expects( $this->at( 0 ) )
+		$skin->expects( $this->exactly( 4 ) )
 			->method( 'makeFooterIcon' )
-			->with( $this->equalTo( 'icon1' ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$skin->expects( $this->at( 1 ) )
-			->method( 'makeFooterIcon' )
-			->with( $this->equalTo( 'icon2' ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$skin->expects( $this->at( 2 ) )
-			->method( 'makeFooterIcon' )
-			->with( $this->equalTo( 'icon3' ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$skin->expects( $this->at( 3 ) )
-			->method( 'makeFooterIcon' )
-			->with( $this->equalTo( 'icon4' ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
+			->withConsecutive(
+				[ $this->equalTo( 'icon1' ) ],
+				[ $this->equalTo( 'icon2' ) ],
+				[ $this->equalTo( 'icon3' ) ],
+				[ $this->equalTo( 'icon4' ) ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' )
+			);
 
 		$chameleonTemplate->expects( $this->any() )
 			->method( 'getFooterIconsWithImage' )

--- a/tests/phpunit/Unit/Components/FooterInfoTest.php
+++ b/tests/phpunit/Unit/Components/FooterInfoTest.php
@@ -48,25 +48,20 @@ class FooterInfoTest extends GenericComponentTestCase {
 	public function testGetHtml_GetsAllKeys() {
 		$chameleonTemplate = $this->getChameleonSkinTemplateStub();
 
-		$chameleonTemplate->expects( $this->at( 1 ) )
+		$chameleonTemplate->expects( $this->exactly( 4 ) )
 			->method( 'get' )
-			->with( $this->equalTo( 'key1' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$chameleonTemplate->expects( $this->at( 2 ) )
-			->method( 'get' )
-			->with( $this->equalTo( 'key2' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$chameleonTemplate->expects( $this->at( 3 ) )
-			->method( 'get' )
-			->with( $this->equalTo( 'key3' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$chameleonTemplate->expects( $this->at( 4 ) )
-			->method( 'get' )
-			->with( $this->equalTo( 'key4' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
+			->withConsecutive(
+				[ $this->equalTo( 'key1' ) ],
+				[ $this->equalTo( 'key2' ) ],
+				[ $this->equalTo( 'key3' ) ],
+				[ $this->equalTo( 'key4' ) ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' )
+			);
 
 		$instance = new $this->classUnderTest( $chameleonTemplate );
 

--- a/tests/phpunit/Unit/Components/FooterInfoTest.php
+++ b/tests/phpunit/Unit/Components/FooterInfoTest.php
@@ -56,12 +56,7 @@ class FooterInfoTest extends GenericComponentTestCase {
 				[ $this->equalTo( 'key3' ) ],
 				[ $this->equalTo( 'key4' ) ]
 			)
-			->willReturnOnConsecutiveCalls(
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' )
-			);
+			->willReturn( $this->returnValue( 'SomeHTML' ) );
 
 		$instance = new $this->classUnderTest( $chameleonTemplate );
 

--- a/tests/phpunit/Unit/Components/FooterPlacesTest.php
+++ b/tests/phpunit/Unit/Components/FooterPlacesTest.php
@@ -54,11 +54,7 @@ class FooterPlacesTest extends GenericComponentTestCase {
 				[ $this->equalTo( 'about' ), $this->equalTo( null ) ],
 				[ $this->equalTo( 'disclaimer' ), $this->equalTo( null ) ]
 			)
-			->willReturnOnConsecutiveCalls(
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' ),
-				$this->returnValue( 'SomeHTML' )
-			);
+			->willReturn( $this->returnValue( 'SomeHTML' ) );
 
 		$instance = new $this->classUnderTest( $chameleonTemplate );
 

--- a/tests/phpunit/Unit/Components/FooterPlacesTest.php
+++ b/tests/phpunit/Unit/Components/FooterPlacesTest.php
@@ -47,20 +47,18 @@ class FooterPlacesTest extends GenericComponentTestCase {
 	public function testGetHtml_GetsAllKeys() {
 		$chameleonTemplate = $this->getChameleonSkinTemplateStub();
 
-		$chameleonTemplate->expects( $this->at( 1 ) )
+		$chameleonTemplate->expects( $this->exactly( 3 ) )
 			->method( 'get' )
-			->with( $this->equalTo( 'privacy' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$chameleonTemplate->expects( $this->at( 2 ) )
-			->method( 'get' )
-			->with( $this->equalTo( 'about' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
-
-		$chameleonTemplate->expects( $this->at( 3 ) )
-			->method( 'get' )
-			->with( $this->equalTo( 'disclaimer' ), $this->equalTo( null ) )
-			->will( $this->returnValue( 'SomeHTML' ) );
+			->withConsecutive(
+				[ $this->equalTo( 'privacy' ), $this->equalTo( null ) ],
+				[ $this->equalTo( 'about' ), $this->equalTo( null ) ],
+				[ $this->equalTo( 'disclaimer' ), $this->equalTo( null ) ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' ),
+				$this->returnValue( 'SomeHTML' )
+			);
 
 		$instance = new $this->classUnderTest( $chameleonTemplate );
 

--- a/tests/phpunit/Unit/Hooks/SetupAfterCacheTest.php
+++ b/tests/phpunit/Unit/Hooks/SetupAfterCacheTest.php
@@ -81,17 +81,19 @@ class SetupAfterCacheTest extends TestCase {
 	public function testProcessWithValidExternalModuleWithoutScssVariables() {
 		$bootstrapManager = $this->createMock( BootstrapManager::class );
 
-		$bootstrapManager->expects( $this->at( 9 ) )
+		$bootstrapManager->expects( $this->exactly( 9 ) )
 			->method( 'addStyleFile' )
-			->with(
-				$this->equalTo( $this->dummyExternalModule )
+			->withConsecutive(
+				[ $this->anything() ],
+				[ $this->anything() ],
+				[ $this->anything() ],
+				[ $this->anything() ],
+				[ $this->anything() ],
+				[ $this->anything() ],
+				[ $this->anything() ],
+				[ $this->equalTo( $this->dummyExternalModule ) ],
+				[ $this->equalTo( $this->dummyExternalModule ),	$this->equalTo( 'somePositionWeDontCheck' ) ]
 			);
-
-		$bootstrapManager->expects( $this->at( 10 ) )
-			->method( 'addStyleFile' )
-			->with(
-				$this->equalTo( $this->dummyExternalModule ),
-				$this->equalTo( 'somePositionWeDontCheck' ) );
 
 		$bootstrapManager->expects( $this->once() )
 			->method( 'setScssVariable' )


### PR DESCRIPTION
To fix the test warnings caused by PHPUnit 9 + MW master: https://github.com/ProfessionalWiki/chameleon/actions/runs/3326977881/jobs/5501254610