### PR TITLE
Toc component: style improvements

### DIFF
--- a/resources/styles/Components/Toc.scss
+++ b/resources/styles/Components/Toc.scss
@@ -9,6 +9,7 @@
 .chameleon-toc-wrapper {
 	position: sticky;
 	top: 0;
+	z-index: 1;
 
 	max-height: 100vh;
 	overflow: auto;
@@ -35,9 +36,7 @@
 
 	.toc {
 		border: unset;
-		background-color: unset;
 		font-size: unset;
-		width: 100%;
 
 		ul {
 			display: flex;


### PR DESCRIPTION
Improve the styles for the newly added Toc component, which adds a sticky table of contents:

- Restore a background color for the table.

- With that background color, the table shouldn't take up the entire width of the page, so remove the 100% width.

- Specify `z-index: 1;` for the wrapping div so that reference tooltips from the Cite extension are not shown through the table of contents.

- Restore the ability to toggle the visibility of the table of contents.

WE-279