### PR TITLE
Collapse H2 headings in TOC component

### DIFF
--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -120,6 +120,10 @@
 		});
 
 		setInitialLink();
+
+		$( '.toclevel-1 .toggle' ).click( function () {
+			$( this ).siblings( 'ul' ).collapse( 'toggle' );
+		} );
 	} );
 
 

--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -74,7 +74,8 @@
 	}
 
 	function enableScrollspy() {
-		var offset = 179;
+		// Default offset is one navbar plus extra.
+		var offset = parseFloat( $( '.chameleon-toc-wrapper' ).css( '--scrollspy-offset' ) || 80 );
 
 		// TODO: re-test when using Sticky Modification.
 		// var stickyNavbar = $( '.p-navbar[style*="position"]' );

--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -75,10 +75,12 @@
 
 	function enableScrollspy() {
 		var offset = 179;
-		var stickyNavbar = $( '.p-navbar[style*="position"]' );
-		if ( stickyNavbar.length > 0 ) {
-			offset += stickyNavbar.outerHeight();
-		}
+
+		// TODO: re-test when using Sticky Modification.
+		// var stickyNavbar = $( '.p-navbar[style*="position"]' );
+		// if ( stickyNavbar.length > 0 ) {
+		// 	offset += stickyNavbar.outerHeight();
+		// }
 
 		$( 'body' ).scrollspy( { target: '.chameleon-toc', offset: offset } );
 	}
@@ -112,8 +114,8 @@
 
 	function addTocLinkClickEvent() {
 		$( '.chameleon-toc ul li a').on( 'click', function () {
-			const href = $( this ).attr( 'href' );
-			const anchor = href.substr( href.indexOf( '#' ) );
+			var href = $( this ).attr( 'href' );
+			var anchor = href.substr( href.indexOf( '#' ) );
 
 			// Trigger hashchange event when hash is the same (for sticky navbar).
 			if ( window.location.hash === anchor ) {

--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -31,14 +31,49 @@
 
     'use strict';
 
-	$( function () {
-		if ( window.outerWidth < 768 ) {
-			$( '.chameleon-toc' ).remove();
+	function goToLink( $link ) {
+		var $activeLink = $( '.chameleon-toc .active' );
+
+		if ( $activeLink.last().is( $link ) ) {
 			return;
 		}
 
-		$( '#bodyContent #toc' ).remove();
+		$activeLink.removeClass( 'active' );
 
+		$link.addClass( 'active' );
+		$link.parents( '.nav' ).prev( '.nav-link'  + ", " +  '.list-group-item' ).addClass( 'active' );
+		$link.parents( '.nav' ).prev( '.nav-item' ).children( '.nav-link' ).addClass( 'active' );
+	}
+
+	function getCurrentHash() {
+		var hash = window.location.hash;
+		return hash.substring( hash.indexOf( '#' ) )
+	}
+
+	function setInitialLink() {
+		var hash = getCurrentHash();
+		var activeLink = $('.chameleon-toc a.active');
+		var targetLink;
+
+		if ( hash === '' && activeLink.length === 0) {
+			targetLink = $( '.chameleon-toc a.top' );
+		} else {
+			targetLink = $( '.chameleon-toc a[href="' + hash + '"]' );
+		}
+		if ( targetLink.length !== 0 ) {
+			targetLink.parents( '.nav.collapse' ).collapse('show');
+			goToLink( targetLink );
+		}
+	}
+
+	function rearrangeToggleButtons() {
+		// Move toggle buttons after collapsible nav for styling purposes.
+		$( '.chameleon-toc .btn.toggle' ).each( function() {
+			$( this ).insertAfter( $( this ).nextAll ( '.nav' ) );
+		} );
+	}
+
+	function enableScrollspy() {
 		var offset = 179;
 		var stickyNavbar = $( '.p-navbar[style*="position"]' );
 		if ( stickyNavbar.length > 0 ) {
@@ -46,47 +81,22 @@
 		}
 
 		$( 'body' ).scrollspy( { target: '.chameleon-toc', offset: offset } );
+	}
 
-		// Move toggle buttons after collapsible nav for styling purposes.
-		$( '.chameleon-toc .btn.toggle' ).each( function() {
-			$( this ).insertAfter( $( this ).nextAll ( '.nav' ) );
-		} );
+	function addScrollspyEvent() {
+		// Highlight and scroll to value in TOC when scrolling in body.
+		$( window ).on( 'activate.bs.scrollspy', function ( e, obj ) {
+			var clickedLink = $( '.chameleon-toc .clicked' );
 
-		function goToLink( $link ) {
-			var $activeLink = $( '.chameleon-toc .active' );
-
-			if ( $activeLink.last().is( $link ) ) {
+			if ( clickedLink.length === 0 ) {
 				return;
 			}
 
-			$activeLink.removeClass( 'active' );
+			goToLink( clickedLink );
+		});
+	}
 
-			$link.addClass( 'active' );
-			$link.parents( '.nav' ).prev( '.nav-link'  + ", " +  '.list-group-item' ).addClass( 'active' );
-			$link.parents( '.nav' ).prev( '.nav-item' ).children( '.nav-link' ).addClass( 'active' );
-		}
-
-		function getCurrentHash() {
-			var hash = window.location.hash;
-			return hash.substring( hash.indexOf( '#' ) )
-		}
-
-		function setInitialLink() {
-			var hash = getCurrentHash();
-			var activeLink = $('.chameleon-toc a.active');
-			var targetLink;
-
-			if ( hash === '' && activeLink.length === 0) {
-				targetLink = $( '.chameleon-toc a.top' );
-			} else {
-				targetLink = $( '.chameleon-toc a[href="' + hash + '"]' );
-			}
-			if ( targetLink.length !== 0 ) {
-				targetLink.parents( '.nav.collapse' ).collapse('show');
-				goToLink( targetLink );
-			}
-		}
-
+	function addWindowScrollEvent() {
 		$( window ).on( 'scroll', function() {
 			$( '.chameleon-toc a.clicked' ).removeClass( 'clicked' );
 
@@ -98,7 +108,9 @@
 
 			goToLink( $( '.chameleon-toc a.top' ) );
 		} );
+	}
 
+	function addTocLinkClickEvent() {
 		$( '.chameleon-toc ul li a').on( 'click', function () {
 			const href = $( this ).attr( 'href' );
 			const anchor = href.substr( href.indexOf( '#' ) );
@@ -113,24 +125,29 @@
 
 			goToLink( $( this ) );
 		} );
+	}
 
-		// Highlight and scroll to value in TOC when scrolling in body.
-		$( window ).on( 'activate.bs.scrollspy', function ( e, obj ) {
-			var clickedLink = $( '.chameleon-toc .clicked' );
-
-			if ( clickedLink.length === 0 ) {
-				return;
-			}
-
-			goToLink( clickedLink );
-		});
-
-		setInitialLink();
-
+	function addToggleButtonClickEvent() {
 		$( '.toclevel-1 .toggle' ).click( function () {
 			$( this ).siblings( 'ul' ).collapse( 'toggle' );
 		} );
-	} );
+	}
 
+	$( function () {
+		if ( window.outerWidth < 768 ) {
+			$( '.chameleon-toc' ).remove();
+			return;
+		}
+
+		$( '#bodyContent #toc' ).remove();
+
+		rearrangeToggleButtons();
+		enableScrollspy();
+		addScrollspyEvent();
+		addWindowScrollEvent();
+		addTocLinkClickEvent();
+		addToggleButtonClickEvent();
+		setInitialLink();
+	} );
 
 }(window, document, jQuery, mediaWiki) );

--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -82,6 +82,7 @@
 				targetLink = $( '.chameleon-toc a[href="' + hash + '"]' );
 			}
 			if ( targetLink.length !== 0 ) {
+				targetLink.parents( '.nav.collapse' ).collapse('show');
 				goToLink( targetLink );
 			}
 		}

--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -47,6 +47,11 @@
 
 		$( 'body' ).scrollspy( { target: '.chameleon-toc', offset: offset } );
 
+		// Move toggle buttons after collapsible nav for styling purposes.
+		$( '.chameleon-toc .btn.toggle' ).each( function() {
+			$( this ).insertAfter( $( this ).nextAll ( '.nav' ) );
+		} );
+
 		function goToLink( $link ) {
 			var $activeLink = $( '.chameleon-toc .active' );
 

--- a/resources/styles/Components/Toc.scss
+++ b/resources/styles/Components/Toc.scss
@@ -40,7 +40,6 @@
 		width: 100%;
 
 		ul {
-			display: flex;
 			flex-direction: column;
 			margin: 0;
 		}
@@ -72,6 +71,27 @@
 		color: $body-color;
 	}
 
+	.btn.toggle {
+		padding: 0;
+	}
+
+	.toclevel-1 {
+		display: flex;
+		flex-wrap: wrap;
+
+		.toggle {
+			order: -1;
+		}
+
+		.nav {
+			flex-basis: 100%;
+		}
+
+		ul.collapsing {
+			display: flex;
+			flex-wrap: nowrap;
+		}
+	}
 }
 
 .p-navbar.sticky + div .chameleon-toc-wrapper {

--- a/resources/styles/Components/Toc.scss
+++ b/resources/styles/Components/Toc.scss
@@ -122,3 +122,10 @@
 .p-navbar.sticky + div .chameleon-toc-wrapper {
 	top: $navbar-padding-y * 2 + $nav-link-padding-y * 2 + $font-size-base * $line-height-base;
 }
+
+// Hide page TOC to prevent page content shift.
+@include media-breakpoint-up(md) {
+	#bodyContent #toc {
+		display: none;
+	}
+}

--- a/resources/styles/Components/Toc.scss
+++ b/resources/styles/Components/Toc.scss
@@ -49,6 +49,10 @@
 		}
 	}
 
+	li {
+		margin-bottom: 0;
+	}
+
 	.toctogglecheckbox:checked ~ ul {
 		display: none;
 	}
@@ -73,6 +77,21 @@
 
 	.btn.toggle {
 		padding: 0;
+		margin-right: 5px;
+		width: 12px;
+		margin-left: -1rem;
+	}
+
+	.toggle-icon {
+		display: block;
+	}
+
+	.toggle-icon::before {
+		content: "+";
+	}
+
+	.nav.show ~ .btn.toggle .toggle-icon::before {
+		content: "-";
 	}
 
 	.toclevel-1 {
@@ -90,6 +109,12 @@
 		ul.collapsing {
 			display: flex;
 			flex-wrap: nowrap;
+		}
+	}
+
+	&.has-collapsible {
+		.toc > ul {
+			margin-left: 1rem;
 		}
 	}
 }

--- a/src/Components/Toc.php
+++ b/src/Components/Toc.php
@@ -54,7 +54,19 @@ class Toc extends Component {
 		$html = str_replace( '<ul>', '<ul class="nav">', $html );
 		$html = str_replace( '<a href', '<a class="nav-link" href', $html );
 
-		return '<div class="chameleon-toc-wrapper"><div class="chameleon-toc">' . $html . '</div></div>';
+		// Add collapsible button
+		$count = 0;
+		$html = preg_replace(
+			'|(<li class="toclevel-1.*?)(<a.*?</a>[\s\n]*?)<ul class="|i',
+			'$1<button class="btn toggle">+</button>$2<ul class="collapse ',
+			$html,
+			-1,
+			$count
+		);
+
+		$hasCollapsibleClass = $count > 0 ? ' has-collapsible' : '';
+
+		return '<div class="chameleon-toc-wrapper"><div class="chameleon-toc' . $hasCollapsibleClass . '">' . $html . '</div></div>';
 	}
 
 	/**

--- a/src/Components/Toc.php
+++ b/src/Components/Toc.php
@@ -58,7 +58,7 @@ class Toc extends Component {
 		$count = 0;
 		$html = preg_replace(
 			'|(<li class="toclevel-1.*?)(<a.*?</a>[\s\n]*?)<ul class="|i',
-			'$1<button class="btn toggle">+</button>$2<ul class="collapse ',
+			'$1<button class="btn toggle"><span class="toggle-icon"></span></button>$2<ul class="collapse ',
 			$html,
 			-1,
 			$count


### PR DESCRIPTION
Refs https://github.com/ProfessionalWiki/chameleon/issues/390

This collapses the H2 headings in the TOC component and adds collapse/expand buttons similar to the TOC in the Vector 2022 skin:

https://github.com/ProfessionalWiki/chameleon/assets/1428594/738ab5eb-b2dd-41d2-b341-44059a61f36e

TODOs:
* Documentation follow-up
* Tests (since this is based on regexing the TOC HTML)]
* Code can likely do with some cleanup

This PR should be squashed.