### PR TITLE
Remove 'mediawiki.ui.button' from ResourceLoader

### DIFF
--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -232,7 +232,6 @@ class SetupAfterCache {
 		MediaWikiServices::getInstance()->getSkinFactory()->register( 'chameleon', 'Chameleon',
 			function () {
 				$styles = [
-					'mediawiki.ui.button',
 					'skins.chameleon',
 					'zzz.ext.bootstrap.styles',
 				];


### PR DESCRIPTION
Removed one line which was generating an error in the Javascript console:

> Special:Version:200 This page is using the deprecated ResourceLoader module "mediawiki.ui.button".
> [1.41] Please use Codex. See migration guidelines: https://w.wiki/7TAh

Unless I am missing something, mediawiki.ui.button is not used by current version of chameleon skin in any case. 
This edit removes it from the ResourceLoader.