### PR TITLE
Bump minimum requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_35'
-            php: 7.4
-            experimental: false
           - mw: 'REL1_39'
             php: 8.1
             experimental: false

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"irc": "irc://libera.chat:6667/mediawiki"
 	},
 	"require": {
-		"php": ">=7.4.3",
+		"php": ">=8.0.0",
 		"ext-dom": "*",
 		"ext-filter": "*",
 		"composer/installers": "^2|^1.0.12",
@@ -45,7 +45,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "4.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"scripts": {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 ## Release Notes
 
+### Chameleon 5.0.0
+
+Under development.
+
+* Raised minimum MediaWiki version from 1.35 to 1.39
+* Raised minimum PHP version from 7.4.3 to 8.0
+
 ### Chameleon 4.3.0
 
 Released on November 26, 2023.


### PR DESCRIPTION
* Raised minimum MediaWiki version from 1.35 to 1.39
* Raised minimum PHP version from 7.4.3 to 8.0