### PR TITLE
Issue 451 - hanlde headings containg umlauts

### DIFF
--- a/resources/js/Components/Modifications/sticky.js
+++ b/resources/js/Components/Modifications/sticky.js
@@ -59,7 +59,7 @@
 	function adjustScroll() {
 		var $header = $( 'nav.p-navbar.sticky' ),
 			headerHeight = $header.height() + 20,
-			hash = window.location.hash.replace( '#', '' ),
+			hash = decodeURIComponent( window.location.hash.replace( '#', '' ) ),
 			$target = $( '[id="' + hash + '"]' );
 
 		if ( !$header.length || !hash || !$target.length ) {


### PR DESCRIPTION
This PR is related to the issue #451.

This PR contains:

- `decodeURIComponent()` used inside `adjustScroll()` to handle hash with umlauts and other special characters
- now the links inside table of contents which contains umlauts will work as it should

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of encoded URL fragments during page scroll adjustments, ensuring smoother and more accurate navigation to target elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->