### PR TITLE
Run CI on PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - mw: 'REL1_39'
-            php: 8.1
+            php: 8.0
             experimental: false
           - mw: 'REL1_41'
             php: 8.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build environment configuration to use PHP 8.0 for improved compatibility and testing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->