### PR TITLE
Removing ResourceLoaderSkinModule features deprecated since MW 1.43 

### DIFF
--- a/src/Hooks/ResourceLoaderRegisterModules.php
+++ b/src/Hooks/ResourceLoaderRegisterModules.php
@@ -83,6 +83,11 @@ class ResourceLoaderRegisterModules {
 			'toc'
 		];
 
+		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
+			$removed = [ 'i18n-all-lists-margins', 'interface-message-box' ];
+			$features = array_values( array_diff( $features, $removed ) );
+		}
+
 		if ( $this->configuration['egChameleonEnableExternalLinkIcons'] === true ) {
 			$features[] = 'content-links-external';
 		}

--- a/tests/phpunit/Unit/Hooks/ResourceLoaderRegisterModulesTest.php
+++ b/tests/phpunit/Unit/Hooks/ResourceLoaderRegisterModulesTest.php
@@ -133,7 +133,7 @@ class ResourceLoaderRegisterModulesTest extends TestCase {
 	}
 
 	private function getBaseFeatures(): array {
-		return [
+		$features = [
 			'elements',
 			'content-links',
 			'content-media',
@@ -145,6 +145,13 @@ class ResourceLoaderRegisterModulesTest extends TestCase {
 			'i18n-headings',
 			'toc'
 		];
+
+		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
+			$removed = [ 'i18n-all-lists-margins', 'interface-message-box' ];
+			$features = array_values( array_diff( $features, $removed ) );
+		}
+
+		return $features;
 	}
 
 }


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/chameleon/issues/460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved feature management for users on the latest system versions. The update now automatically excludes legacy functionalities on supported environments, ensuring that only the most relevant features are active. This change results in a more consistent, streamlined, and stable experience, enhancing overall compatibility with modern platform requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->