### PR TITLE
Use namespaced version of \Html

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -13,7 +13,7 @@
 	"descriptionmsg": "chameleon-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
+		"MediaWiki": ">= 1.40.0",
 		"extensions": {
 			"Bootstrap": "~5.0"
 		}

--- a/src/Components/Container.php
+++ b/src/Components/Container.php
@@ -26,6 +26,7 @@
 
 namespace Skins\Chameleon\Components;
 
+use MediaWiki\Html\Html;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -46,7 +47,7 @@ class Container extends Structure {
 	/**
 	 * Builds the HTML code for the main container
 	 *
-	 * @return String the HTML code
+	 * @return string the HTML code
 	 * @throws \MWException
 	 */
 	public function getHtml() {
@@ -57,7 +58,7 @@ class Container extends Structure {
 			$attribs['id'] = IdRegistry::getRegistry()->getId( $id );
 		}
 
-		$ret = $this->indent() . \Html::openElement( 'div', $attribs );
+		$ret = $this->indent() . Html::openElement( 'div', $attribs );
 		$this->indent( 1 );
 
 		$ret .= parent::getHtml();

--- a/src/Components/Logo.php
+++ b/src/Components/Logo.php
@@ -26,7 +26,7 @@
 
 namespace Skins\Chameleon\Components;
 
-use Linker;
+use MediaWiki\Linker\Linker;
 use Skins\Chameleon\IdRegistry;
 
 /**

--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -26,8 +26,10 @@
 
 namespace Skins\Chameleon\Components;
 
-use Linker;
-use Sanitizer;
+use Exception;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
+use MediaWiki\Parser\Sanitizer;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -46,7 +48,7 @@ class NavMenu extends Component {
 	 * Builds the HTML code for this component
 	 *
 	 * @return string the HTML code
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	public function getHtml() {
 		$ret = '';
@@ -103,7 +105,7 @@ class NavMenu extends Component {
 	 * @param bool $flatten
 	 *
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	protected function getDropdownForNavMenu( $menuName, $menuDescription, $flatten = false ) {
 		// open list item containing the dropdown
@@ -132,7 +134,7 @@ class NavMenu extends Component {
 	 * @param int $indent
 	 *
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	protected function buildMenuItemsForDropdownMenu( $menuDescription, $indent = 0 ) {
 		// build the list of submenu items
@@ -173,16 +175,16 @@ class NavMenu extends Component {
 	 * @param array $menuDescription
 	 *
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	protected function buildDropdownMenuStub( $menuDescription ) {
 		$menuId = $menuDescription['id'];
 
-		return $this->indent() . \Html::rawElement( 'div',
+		return $this->indent() . Html::rawElement( 'div',
 				[
 					'class' => 'nav-item ' . $menuId . '-dropdown',
 				],
-				\Html::rawElement( 'a',
+				Html::rawElement( 'a',
 					[
 						'href' => '#',
 						'class' => 'nav-link ' . $menuId . '-toggle',
@@ -196,20 +198,20 @@ class NavMenu extends Component {
 	 * @param array $menuDescription
 	 *
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	protected function buildDropdownOpeningTags( $menuDescription ) {
 		$menuId = $menuDescription['id'];
 
 		// open list item containing the dropdown
-		$ret = $this->indent() . \Html::openElement( 'div',
+		$ret = $this->indent() . Html::openElement( 'div',
 				[
 					'class' => 'nav-item dropdown ' . $menuId . '-dropdown',
 				] );
 
 		// add the dropdown toggle
 		$ret .= $this->indent( 1 ) .
-			\Html::rawElement( 'a',
+			Html::rawElement( 'a',
 				[
 					'href' => '#',
 					'class' => 'nav-link dropdown-toggle ' . $menuId . '-toggle',
@@ -221,7 +223,7 @@ class NavMenu extends Component {
 
 		// open list of dropdown menu items
 		$ret .=
-			$this->indent() . \Html::openElement( 'div',
+			$this->indent() . Html::openElement( 'div',
 				[
 					'class' => 'dropdown-menu ' . $menuId,
 					'id'    => IdRegistry::getRegistry()->getId( $menuId ),
@@ -232,7 +234,7 @@ class NavMenu extends Component {
 
 	/**
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	protected function buildDropdownClosingTags() {
 		return $this->indent() . '</div>' .

--- a/src/Components/NavbarHorizontal.php
+++ b/src/Components/NavbarHorizontal.php
@@ -27,6 +27,7 @@
 namespace Skins\Chameleon\Components;
 
 use DOMElement;
+use MediaWiki\Html\Html;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -92,7 +93,7 @@ class NavbarHorizontal extends Component {
 
 		$openingTags =
 			$this->indent() . '<!-- navigation bar -->' .
-			$this->indent() . \Html::openElement( 'nav', [
+			$this->indent() . Html::openElement( 'nav', [
 					'class' => $class,
 					'role'  => 'navigation',
 					// FIXME: ID to be repeated in classes
@@ -279,7 +280,7 @@ class NavbarHorizontal extends Component {
 		if ( !filter_var( $this->getAttribute( 'showTogglerText', 'false' ), FILTER_VALIDATE_BOOLEAN ) ) {
 			return '';
 		}
-		return \Html::rawElement( 'span', [ 'class' => 'navbar-toggler-text' ],
+		return Html::rawElement( 'span', [ 'class' => 'navbar-toggler-text' ],
 			$this->getSkinTemplate()->getMsg( 'chameleon-toggler' )->escaped() );
 	}
 

--- a/src/Components/NavbarHorizontal/PageTools.php
+++ b/src/Components/NavbarHorizontal/PageTools.php
@@ -26,6 +26,7 @@
 
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
+use MediaWiki\Html\Html;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\Components\PageTools as GenericPageTools;
 
@@ -57,7 +58,7 @@ class PageTools extends Component {
 		if ( $actionButtonHtmlFragments !== [] || $pageToolsHtml !== '' ) {
 
 			return $this->indent() . '<!-- page tools -->' .
-				$this->indent() . \Html::rawElement( 'div', [ 'class' => 'navbar-tools navbar-nav ' .
+				$this->indent() . Html::rawElement( 'div', [ 'class' => 'navbar-tools navbar-nav ' .
 					$this->getClassString() ],
 					implode( $actionButtonHtmlFragments ) .
 					$pageToolsHtml .
@@ -199,8 +200,8 @@ class PageTools extends Component {
 			return '';
 		}
 
-		return $this->indent() . \Html::rawElement( 'div', [ 'class' => 'navbar-tool dropdown' ],
-				$this->indent( 1 ) . \Html::rawElement( 'a', [ 'data-toggle' => 'dropdown',
+		return $this->indent() . Html::rawElement( 'div', [ 'class' => 'navbar-tool dropdown' ],
+				$this->indent( 1 ) . Html::rawElement( 'a', [ 'data-toggle' => 'dropdown',
 				'data-boundary' => 'viewport', 'class' => 'navbar-more-tools', 'href' => '#',
 				'title' => $this->getSkinTemplate()->getMsg( 'specialpages-group-pagetools' )->text() ] ) .
 				$pageToolsHtml . $this->indent( -1 )

--- a/src/Components/NavbarHorizontal/PersonalTools.php
+++ b/src/Components/NavbarHorizontal/PersonalTools.php
@@ -26,6 +26,7 @@
 
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\IdRegistry;
@@ -104,11 +105,11 @@ class PersonalTools extends Component {
 		return $echoHtml .
 			$this->indent() . '<!-- personal tools -->' .
 			$this->indent() . '<div class="navbar-tools navbar-nav" >' .
-			$this->indent( 1 ) . \Html::rawElement( 'div',
+			$this->indent( 1 ) . Html::rawElement( 'div',
 				[ 'class' => 'navbar-tool' . ( !$this->avatarUrl ? '' : ' avatar' ) . ' dropdown' ],
 
 				$this->getDropdownToggle() .
-				$this->indent( 1 ) . \Html::rawElement( 'div',
+				$this->indent( 1 ) . Html::rawElement( 'div',
 					[ 'class' => 'p-personal-tools dropdown-menu' ],
 					$this->getToolsHtml( $tools ) . $this->indent() ) .
 				$this->indent( -1 )

--- a/src/Components/NavbarHorizontal/Toolbox.php
+++ b/src/Components/NavbarHorizontal/Toolbox.php
@@ -26,8 +26,7 @@
 
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
-use Hooks;
-use Linker;
+use MediaWiki\Linker\Linker;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\IdRegistry;
 
@@ -46,8 +45,8 @@ class Toolbox extends Component {
 	/**
 	 * Builds the HTML code for this component
 	 *
-	 * @return String the HTML code
-	 * @throws \MWException
+	 * @return string the HTML code
+	 * @throws \Exception
 	 */
 	public function getHtml() {
 		$introComment = $this->indent() . '<!-- toolbox -->';
@@ -68,7 +67,7 @@ class Toolbox extends Component {
 	 *
 	 * @return string[]
 	 * @throws \FatalError
-	 * @throws \MWException
+	 * @throws \Exception
 	 */
 	private function getLinkListItems( $indent = 0 ) {
 		$this->indent( $indent );

--- a/src/Components/NewtalkNotifier.php
+++ b/src/Components/NewtalkNotifier.php
@@ -26,6 +26,9 @@
 
 namespace Skins\Chameleon\Components;
 
+use Exception;
+use MediaWiki\Html\Html;
+
 /**
  * The NewtalkNotifier class.
  *
@@ -40,8 +43,8 @@ class NewtalkNotifier extends Component {
 	/**
 	 * Builds the HTML code for this component
 	 *
-	 * @return String the HTML code
-	 * @throws \MWException
+	 * @return string the HTML code
+	 * @throws Exception
 	 */
 	public function getHtml() {
 		$data = $this->getSkinTemplate()->data;
@@ -49,7 +52,7 @@ class NewtalkNotifier extends Component {
 		if ( array_key_exists( 'newtalk', $data ) && $data[ 'newtalk' ] ) {
 			return $this->indent() .
 				'<!-- new talk notifier message to a user about new messages on their talkpage -->' .
-			  $this->indent() . \Html::rawElement( 'div', [ 'class' => 'usermessage ' .
+			  $this->indent() . Html::rawElement( 'div', [ 'class' => 'usermessage ' .
 				$this->getClassString() ], $data[ 'newtalk' ] );
 		} else {
 			return '';

--- a/src/Components/SearchBar.php
+++ b/src/Components/SearchBar.php
@@ -26,8 +26,9 @@
 
 namespace Skins\Chameleon\Components;
 
-use Linker;
-use Skin;
+use Exception;
+use MediaWiki\Linker\Linker;
+use MediaWiki\Html\Html;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -45,10 +46,10 @@ class SearchBar extends Component {
 	 * Builds the HTML code for this component
 	 *
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	public function getHtml() {
-		$attribsSearchFormWrapper = \Html::expandAttributes( [
+		$attribsSearchFormWrapper = Html::expandAttributes( [
 				'id'    => IdRegistry::getRegistry()->getId( 'p-search' ),
 				'class' => 'p-search ' . $this->getClassString(),
 				'role'  => 'search',
@@ -57,7 +58,7 @@ class SearchBar extends Component {
 
 		$tooltipSearchFormWrapper = Linker::tooltip( 'p-search' );
 
-		$attribsSearchForm = \Html::expandAttributes( [
+		$attribsSearchForm = Html::expandAttributes( [
 				'id'    => IdRegistry::getRegistry()->getId( 'searchform' ),
 				'class' => 'mw-search',
 				'action' => $this->getSkinTemplate()->data[ 'wgScript' ],
@@ -107,7 +108,7 @@ class SearchBar extends Component {
 
 	/**
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	private function getGoButton() {
 		$valueAttr = 'searcharticle';
@@ -120,7 +121,7 @@ class SearchBar extends Component {
 
 	/**
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	private function getSearchButton() {
 		$valueAttr = 'searchbutton';
@@ -139,7 +140,7 @@ class SearchBar extends Component {
 	 * @param string $glyphicon
 	 *
 	 * @return string
-	 * @throws \MWException
+	 * @throws Exception
 	 */
 	private function getButton( $button, $valueAttr, $idAttr, $nameAttr, $glyphicon ) {
 		if ( $this->shouldShowButton( $button ) ) {
@@ -158,7 +159,7 @@ class SearchBar extends Component {
 				Linker::tooltipAndAccesskeyAttribs( "search-$nameAttr" )
 			);
 
-			return $this->indent() . \Html::rawElement( 'button', $buttonAttrs );
+			return $this->indent() . Html::rawElement( 'button', $buttonAttrs );
 		}
 
 		return '';

--- a/src/IdRegistry.php
+++ b/src/IdRegistry.php
@@ -26,6 +26,8 @@
 
 namespace Skins\Chameleon;
 
+use MediaWiki\Html\Html;
+
 /**
  * Class IdRegistry provides a registry and access methods to ensure each id is only used once per
  * HTML page.
@@ -93,7 +95,7 @@ class IdRegistry {
 	public function openElement( $tag, $attributes = [] ) {
 		$attributes = $this->getAttributesWithUniqueId( $attributes );
 
-		return \Html::openElement( $tag, $attributes );
+		return Html::openElement( $tag, $attributes );
 	}
 
 	/**
@@ -111,7 +113,7 @@ class IdRegistry {
 	public function element( $tag, $attributes = [], $contents = '', $indent = '' ) {
 		$attributes = $this->getAttributesWithUniqueId( $attributes );
 
-		return $indent . \Html::rawElement( $tag, $attributes, $contents . $indent );
+		return $indent . Html::rawElement( $tag, $attributes, $contents . $indent );
 	}
 
 	/**

--- a/tests/phpunit/Util/MockupFactory.php
+++ b/tests/phpunit/Util/MockupFactory.php
@@ -24,8 +24,9 @@
 
 namespace Skins\Chameleon\Tests\Util;
 
-use Config;
-use FauxRequest;
+use MediaWiki\Config;
+use MediaWiki\Request\FauxRequest;
+use MediaWiki\Title\Title;
 use Message;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -33,8 +34,6 @@ use Skins\Chameleon\Chameleon;
 use Skins\Chameleon\ChameleonTemplate;
 use Skins\Chameleon\ComponentFactory;
 use Skins\Chameleon\Components\Component;
-use stdClass;
-use Title;
 use User;
 
 // @codingStandardsIgnoreStart
@@ -96,7 +95,7 @@ class MockupFactory {
 		$chameleonTemplate->data = $this->getSkinTemplateDummyDataSetForMainNamespace();
 
 		$dataMap = array_map(
-			function ( $key, $value ) {
+			static function ( $key, $value ) {
 				return [ $key, null, $value ];
 			},
 			array_keys( $chameleonTemplate->data ),
@@ -123,7 +122,6 @@ class MockupFactory {
 			->method( 'getSidebar' )
 			->will( $this->testCase->returnValue( [] ) );
 
-
 		if ( version_compare( MW_VERSION, '1.41', '<' ) ) {
 			$chameleonTemplate->expects( $this->testCase->any() )
 				->method( 'getToolbox' )
@@ -136,7 +134,7 @@ class MockupFactory {
 				'foo' => [ 'id' => 'pt-foo' ],
 				'bar' => [ 'id' => 'pt-bar' ],
 				'notifications-alert' => [ 'id' => 'pt-notifications-alert' ],
-				'notifications-notice' => [ 'id' => 'pt-notifications-notice'],
+				'notifications-notice' => [ 'id' => 'pt-notifications-notice' ],
 			] ) );
 
 		$chameleonTemplate->expects( $this->testCase->any() )
@@ -280,7 +278,7 @@ class MockupFactory {
 		return $skin;
 	}
 
-	protected function getConfigStub(): MockObject{
+	protected function getConfigStub(): MockObject {
 		$config = $this->testCase->getMockBuilder( Config::class )
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
See https://phabricator.wikimedia.org/T388624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the navigation component’s internal handling of HTML element references for enhanced code clarity and maintainability. No changes affect the application’s visible features.
	- Streamlined exception handling across components by adopting a more generic exception type.
	- Updated method signatures to align with PHP's type conventions, enhancing code consistency.
	- Updated import statements for better namespace management and clarity. 

- **Chores**
	- Updated the MediaWiki dependency version requirement to ensure compatibility with version 1.40.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->