### PR TITLE
Add aliases to support MediaWiki 1.44

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,7 @@
 Under development.
 
 * Removed deprecated ResourceLoaderRegisterModules features (thanks @lyrixn)
+* Improved compatibility with MediaWiki 1.44 (thanks @physikerwelt and @malberts)
 
 ### Chameleon 5.0.0
 

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -186,3 +186,12 @@ class Chameleon extends SkinTemplate {
 		return $GLOBALS[ 'egChameleonThemeFile' ];
 	}
 }
+
+// Support MediaWiki 1.39 and 1.44. Remove this when dropping support for 1.39.
+// Aliases as per https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1124809
+if ( version_compare( MW_VERSION, '1.44', '>=' ) ) {
+	class_alias( \MediaWiki\Html\Html::class, 'Html' );
+	class_alias( \MediaWiki\Linker\Linker::class, 'Linker' );
+	class_alias( \MediaWiki\Request\FauxRequest::class, 'FauxRequest' );
+	class_alias( \MediaWiki\Title\Title::class, 'Title' );
+}


### PR DESCRIPTION
Add removed aliases instead of removing MW 1.39 support (https://github.com/ProfessionalWiki/chameleon/pull/462).

I'd like to keep MW 1.39 support in case we get around to adding Bootstrap 5.3 support (https://github.com/ProfessionalWiki/chameleon/issues/385) while still supporting MW 1.39.

There is the accidental risk that using this might allow an unrelated extension to also work with MW 1.44 when it would've required updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced compatibility with MediaWiki version 1.44, ensuring smoother performance and broader version support for end users.
- **Documentation**
  - Updated the release notes to reflect the new compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->