### PR TITLE
Prepare for release 5.0.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,11 +1,11 @@
 ## Release Notes
 
-### Chameleon 5.x.x
+### Chameleon 5.0.1
 
-Under development.
+Released on March 30, 2025.
 
 * Removed deprecated ResourceLoaderRegisterModules features (thanks @lyrixn)
-* Improved compatibility with MediaWiki 1.44 (thanks @physikerwelt and @malberts)
+* Added initial compatibility with MediaWiki 1.44 (thanks @physikerwelt and @malberts)
 
 ### Chameleon 5.0.0
 

--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
 		"Morne Alberts",
 		"[https://www.EntropyWins.wtf/mediawiki Jeroen De Dauw]"
 	],
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"url": "https://www.mediawiki.org/wiki/Skin:Chameleon",
 	"descriptionmsg": "chameleon-desc",
 	"license-name": "GPL-3.0-or-later",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated release notes now reflect the official release of the Chameleon skin, including the initial compatibility with MediaWiki 1.44.
- **Chores**
  - Version number bumped to 5.0.1 to mark this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->