### PR TITLE
Declare skin to be responsive, remove extra viewport tag (fixes #470)

### DIFF
--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -95,16 +95,6 @@ class Chameleon extends SkinTemplate {
 	}
 
 	/**
-	 * @param OutputPage $out
-	 */
-	public function initPage( OutputPage $out ) {
-		parent::initPage( $out );
-
-		// Enable responsive behaviour on mobile browsers
-		$out->addMeta( 'viewport', 'width=device-width, initial-scale=1, shrink-to-fit=no' );
-	}
-
-	/**
 	 * @inheritDoc
 	 */
 	protected function prepareQuickTemplate() {

--- a/src/Hooks/SetupAfterCache.php
+++ b/src/Hooks/SetupAfterCache.php
@@ -239,6 +239,7 @@ class SetupAfterCache {
 				return new Chameleon( [
 					'name' => 'chameleon',
 					'styles' => $styles,
+					'responsive' => true,
 					'bodyOnly' => true
 				] );
 			} );


### PR DESCRIPTION
 * Tell the MW core that this skin supports responsive behavior.
 * Stop manually emitting a "viewport" meta tag from Chameleon.

MW `Skin` always emits a "viewport" meta tag --- but it needs to know if a skin supports responsive behavior in order to emit the correct tag.

On top of that, the additional tag which `Chameleon` was emitting was either redundant, or had different/competing values for `width` (so some mobile browsers still performed non-responsive rendering, despite the extra tag).