### PR TITLE
Fix table caption

### DIFF
--- a/resources/styles/_basics.scss
+++ b/resources/styles/_basics.scss
@@ -42,5 +42,5 @@ ol, ul {
 }
 
 table > caption {
-	caption-side: top;
+	caption-side: initial;
 }


### PR DESCRIPTION
While MediaWiki's native CSS is agnostic about it, Bootstrap has a default of `caption-side: bottom` for the caption element. That's fine for figures but not a happy choice for table captions. Conventionally I think, the expectation is for a table caption to come at the top rather than at the bottom of the table. 

For one place where MediaWiki uses table captions, see the extension categories (Special, API, etc.) on Special:Version. 

I was going to suggest that we should explicitly set `caption-side` to `top`, but in hindsight, a safer choice is to set it to `initial` and let the browser decide, which seems to be in line with MediaWiki's approach. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted table caption positioning styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->