### PR TITLE
Remove manual installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,24 +4,19 @@
 
 - PHP 8.0.0 or later (tested up to PHP 8.3)
 - MediaWiki 1.39 or later (tested up to MediaWiki 1.43)
+- [Composer][composer]
 
 ### Installation
 
-There are two methods for installing Chameleon: with or without [Composer][composer].
-
-If you install Chameleon with Composer, further required software packages will be installed
-automatically. In this case, it is *not* necessary to install any dependencies. Composer will
-take care of that.
-
-If you install Chameleon without Composer, you will need to install and enable the
-[Bootstrap extension][bootstrap] before you install and enable Chameleon.
+Further required software packages will be installed automatically. It is *not*
+necessary to install any dependencies. Composer will take care of that.
 
 If unsure try the detailed installation instructions for
 [Windows](installation-windows.md) or [Linux](installation-linux.md).
 
 Here is the short version:
 
-#### Installation with Composer
+#### Installation
 
 On a command line go to your MediaWiki installation directory and run these two commands
 
@@ -51,34 +46,13 @@ Save the file. To verifying Chameleon was installed correctly, navigate to _Spec
 If you run into problems, try the
 [troubleshooting](installation-troubleshooting.md).
 
-#### Installation without Composer
-
-1. Install and enable the [Bootstrap][bootstrap] extension.
-
-2. [Download][download] Chameleon and place the file(s) in a directory called **c**hameleon in your
-    skins/ folder.
-
-3. Add the following code at the bottom of your LocalSettings.php:
-
-   ```php
-   wfLoadSkin( 'chameleon' );
-	```
-
-   To set Chameleon as the default skin, find `$wgDefaultSkin` and amend it:
-   ```php
-   $wgDefaultSkin = 'chameleon';
-   ```
-
-4. __Done:__ Navigate to _Special:Version_ on your wiki to verify that the skin
-   is successfully installed.
-
-### Update with Composer
+### Update
 
 From your MediaWiki installation directory run `composer update "mediawiki/chameleon-skin" --no-dev -o`
 
 If you want to upgrade from Chameleon 4.x to 5.x, first edit `composer.local.json`. Change `"mediawiki/chameleon-skin": "~4.0"` to `"mediawiki/chameleon-skin": "~5.0"`.
 
-### De-installation with Composer
+### De-installation
 
 Before de-installation make sure you secure (move, backup) any custom files you
 might want to retain.
@@ -88,5 +62,3 @@ Remove the Chameleon skin from the `composer.local.json` file. Then run
 directory.
 
 [composer]: https://getcomposer.org/
-[bootstrap]: https://www.mediawiki.org/wiki/Extension:Bootstrap
-[download]: https://github.com/ProfessionalWiki/chameleon/archive/master.zip


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/chameleon/issues/411#issuecomment-3548597880

Basically reverts the installation instructions in https://github.com/ProfessionalWiki/chameleon/commit/af3d0e189bbbedb8f16b96ff52c65a6591de5405, due to the dependency added in https://github.com/ProfessionalWiki/chameleon/pull/299.