### PR TITLE
Allow for grids without container classes

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -88,12 +88,13 @@ recommended.
 
 #### Attributes:
 * `mode`:
-  * Allowed values: String (`fixedwidth`|`fluid`|`sm`|`md`|`lg`|`xl`|`xxl`)
+  * Allowed values: String (`fixedwidth`|`fluid`|`simple`|`sm`|`md`|`lg`|`xl`|`xxl`)
   * Default: `fixedwidth`
   * Optional.
 
   Use `fixedwidth` for a responsive fixed width layout. Use `fluid` for a full
-  width layout, spanning the entire width of the viewport.
+  width layout, spanning the entire width of the viewport, with some padding.
+  Use `simple` if you need to omit any `container` classes from Bootstrap.
 
   Use a breakpoint name for a responsive container (since Chameleon 4.1.0).
 

--- a/layouts/layout.rng
+++ b/layouts/layout.rng
@@ -86,6 +86,7 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 						<value>xl</value>
 						<value>xxl</value>
 						<value>fluid</value>
+						<value>simple</value>
 					</choice>
 				</attribute>
 			</optional>

--- a/src/Components/Grid.php
+++ b/src/Components/Grid.php
@@ -45,6 +45,7 @@ class Grid extends Container {
 	private const MODE_XL = 'xl';
 	private const MODE_XXL = 'xxl';
 	private const MODE_FLUID = 'fluid';
+	private const MODE_SIMPLE = 'simple';
 
 	private const VALID_MODES = [
 		self::MODE_FIXEDWIDTH,
@@ -53,7 +54,8 @@ class Grid extends Container {
 		self::MODE_LG,
 		self::MODE_XL,
 		self::MODE_XXL,
-		self::MODE_FLUID
+		self::MODE_FLUID,
+		self::MODE_SIMPLE
 	];
 
 	/**
@@ -68,6 +70,8 @@ class Grid extends Container {
 		$mode = $this->getAttribute( self::ATTR_MODE, self::MODE_FIXEDWIDTH );
 		if( $mode === self::MODE_FIXEDWIDTH || !in_array( $mode, self::VALID_MODES ) ) {
 			$this->addClasses( 'container' );
+		} elseif( $mode === self::MODE_SIMPLE ) {
+			// No class
 		} else {
 			$this->addClasses( 'container-' . $mode );
 		}


### PR DESCRIPTION
Sometimes you just need a div element without any of Bootstrap's container classes. This patch adds "simple" as another possible value to Grid's "mode". If mode is set to "simple", none of the container classes will be added. Of course, you can still use the class attribute, for instance to add your own classes relating to flexbox and grid frameworks. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "simple" mode for the Grid component, which omits Bootstrap container classes.

* **Documentation**
  * Updated Grid component documentation to include the new simple mode and document its layout behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->