### PR TITLE
WIP Update to Bootstrap 5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: 8.0
-            experimental: false
-          - mw: 'REL1_41'
+          - mw: 'REL1_43'
             php: 8.1
             experimental: false
-          - mw: 'REL1_42'
+          - mw: 'REL1_44'
             php: 8.2
             experimental: false
-          - mw: 'REL1_43'
+          - mw: 'REL1_45'
             php: 8.3
             experimental: false
           - mw: 'master'
             php: 8.4
+            experimental: true
+          - mw: 'master'
+            php: 8.5
             experimental: true
 
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ the MediaWiki IRC channel (Server: [libera.chat][irc] Channel: #mediawiki), and 
 [mw-chameleon]: https://www.mediawiki.org/wiki/Skin:Chameleon
 [mw-chameleon-talk]: https://www.mediawiki.org/wiki/Skin_talk:Chameleon
 [composer]: https://getcomposer.org/
-[twbs]: http://getbootstrap.com/
+[twbs]: https://getbootstrap.com/
 [license]: https://www.gnu.org/copyleft/gpl.html
 
 [open bugs]: https://github.com/ProfessionalWiki/chameleon/issues

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "mediawiki/chameleon-skin",
 	"type": "mediawiki-skin",
-	"description": "A highly flexible MediaWiki skin using Bootstrap 4",
+	"description": "A highly flexible MediaWiki skin using Bootstrap 5",
 	"keywords": [
 		"wiki",
 		"MediaWiki",
@@ -31,11 +31,11 @@
 		"irc": "irc://libera.chat:6667/mediawiki"
 	},
 	"require": {
-		"php": ">=8.0.0",
+		"php": ">=8.1.0",
 		"ext-dom": "*",
 		"ext-filter": "*",
 		"composer/installers": "^2|^1.0.12",
-		"mediawiki/bootstrap": "^5.0",
+		"mediawiki/bootstrap": "6.x-dev",
 		"jeroen/file-fetcher": "^6",
 		"psr/http-message": "^1"
 	},
@@ -45,7 +45,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "5.x-dev"
+			"dev-master": "6.x-dev"
 		}
 	},
 	"scripts": {

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -35,15 +35,15 @@ Composer tool during installation. These are:
 * MediaWiki Bootstrap extension, which provides the Twitter Bootstrap
   framework (version 4) to other MediaWiki extensions and skins. Author: Stephan
   Gambke. See https://www.mediawiki.org/wiki/Extension:Bootstrap
-* Bootstrap 4, the most popular HTML, CSS, and JS framework for
+* Bootstrap 5, the most popular HTML, CSS, and JS framework for
   developing responsive, mobile-first projects on the web. Maintained by the
-  [Bootstrap team](https://getbootstrap.com/docs/4.3/about/team/). See
+  [Bootstrap team](https://getbootstrap.com/docs/5.3/about/team/). See
   http://getbootstrap.com/
 * Font-Awesome, a full suite of pictographic icons for easy scalable vector
   graphics on websites, created and maintained by Dave Gandy. See
   http://fontawesome.io/
-* scssphp, a compiler for SCSS written in PHP. Author: Leaf Corcoran. See
-  http://leafo.github.io/scssphp/  
+* scssphp, a compiler for SCSS written in PHP. See
+  https://github.com/scssphp/scssphp
 * loads of other software that I either forgot, am not aware of or that should
   be obvious (e.g. PHP, MediaWiki, etc.)
 

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -10,13 +10,13 @@ Translations have been provided by the members of the [Translatewiki.net
 project](https://translatewiki.net).
 
 The "Chameleon Skin Logo" was derived from the ["Chameleon free
-icon"](http://www.flaticon.com/free-icon/chameleon_36320) made by
-[Freepik](http://www.freepik.com) from
-[www.flaticon.com](http://www.flaticon.com), which is licensed under [CC BY
-3.0](http://creativecommons.org/licenses/by/3.0/). The ["Chameleon Skin
+icon"](https://www.flaticon.com/free-icon/chameleon_36320) made by
+[Freepik](https://www.freepik.com) from
+[www.flaticon.com](https://www.flaticon.com), which is licensed under [CC BY
+3.0](https://creativecommons.org/licenses/by/3.0/). The ["Chameleon Skin
 Logo"](Chameleon.svg) itself
 was created by [Stephan Gambke](https://www.mediawiki.org/wiki/User:F.trott) and
-is licensed under [CC BY 3.0](http://creativecommons.org/licenses/by/3.0/) as
+is licensed under [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) as
 well.
 
 ### Included libraries
@@ -24,7 +24,7 @@ well.
 The following libraries are included:
 * [HC-Sticky](https://github.com/somewebmedia/hc-sticky), a dependency free
   javascript library that makes any element on your page visible while you
-  scroll. Author: [Some Web Media](http://somewebmedia.com)
+  scroll. Author: [Some Web Media](https://somewebmedia.com)
 
 
 ### Dependencies
@@ -38,10 +38,10 @@ Composer tool during installation. These are:
 * Bootstrap 5, the most popular HTML, CSS, and JS framework for
   developing responsive, mobile-first projects on the web. Maintained by the
   [Bootstrap team](https://getbootstrap.com/docs/5.3/about/team/). See
-  http://getbootstrap.com/
+  https://getbootstrap.com/
 * Font-Awesome, a full suite of pictographic icons for easy scalable vector
   graphics on websites, created and maintained by Dave Gandy. See
-  http://fontawesome.io/
+  https://fontawesome.io/
 * scssphp, a compiler for SCSS written in PHP. See
   https://github.com/scssphp/scssphp
 * loads of other software that I either forgot, am not aware of or that should

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,4 @@ particular version of the skin.
 8. [Contact](contact.md)
 
 [mw]: https://www.mediawiki.org/
-[twbs]: http://getbootstrap.com/
+[twbs]: https://getbootstrap.com/

--- a/docs/installation-linux.md
+++ b/docs/installation-linux.md
@@ -64,4 +64,4 @@ operating systems as well:
    (On Firefox or Chrome press Ctrl+F5)
 
 [Install Composer]: https://getcomposer.org/doc/00-intro.md#installation-nix
-[cache-refresh]: http://www.refreshyourcache.com/en/home/
+[cache-refresh]: https://www.refreshyourcache.com/en/home/

--- a/docs/installation-windows.md
+++ b/docs/installation-windows.md
@@ -72,6 +72,6 @@ Here is a step by step procedure for Windows:
     Ctrl+Shift+F5 on Internet Explorer.)
 
 [composer-installer]: https://getcomposer.org/Composer-Setup.exe
-[Notepad++]: http://notepad-plus-plus.org/
-[Kate]:http://kate-editor.org/
-[cache-refresh]: http://www.refreshyourcache.com/en/home/
+[Notepad++]: https://notepad-plus-plus.org/
+[Kate]:https://kate-editor.org/
+[cache-refresh]: https://www.refreshyourcache.com/en/home/

--- a/docs/legal.md
+++ b/docs/legal.md
@@ -42,7 +42,7 @@ Some cases I can think of:
   compatibility.
 * Chameleon itself might become part of a tarball, e.g. some pre-build,
   pre-configured wiki for I don't know what purpose.
-* Parts of the skin might be included in other software. 
+* Parts of the skin might be included in other software.
 * If I get it right, it might be possible to use this skin (or a derivative)
   for other frameworks than MediaWiki. Didn't look into that, but it's
   conceivable.
@@ -102,4 +102,4 @@ that the one was not derived from the other.
 [why-upgrade]: https://www.gnu.org/licenses/rms-why-gplv3.html
 [wmf-git-server]: https://git.wikimedia.org/
 [patch-uploader]: https://tools.wmflabs.org/gerrit-patch-uploader/
-[WTFPL]: http://www.wtfpl.net
+[WTFPL]: https://www.wtfpl.net

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,10 +1,24 @@
-# Migrating to Chameleon 2.0:
+# Migrating to Chameleon 6.0:
+
+## Core items changed
+
+* Move from Bootstrap 4 to [Bootstrap 5](https://getbootstrap.com/docs/5.3)
+
+Please also see the [release notes](release-noted.md).
+
+## New minimum version requirements
+
+Chameleon 6 supports
+* MediaWiki 1.43.0 and later
+* PHP 8.1 and later
+
+TODO
 
 ## Core items changed
 
 * Move from Bootstrap 3 to [Bootstrap 4](https://getbootstrap.com/docs/4.3)
 * Move from Less to [SCSS](https://sass-lang.com/) (Sass)
-* New way of setting style variables in LocalSettings.php 
+* New way of setting style variables in LocalSettings.php
 * Component name changes
 
 Please also see the [release notes](release-noted.md).
@@ -26,7 +40,7 @@ It should be enough to update `composer.local.json`, run `composer update` and a
 
 ## Move from Bootstrap 3 to Bootstrap 4
 
-Chameleon 2.0 comes with [Bootstrap 4](https://getbootstrap.com/docs/4.3), an upgraded version of Bootstrap 3 that came with Chameleon 1.x. Class names from Bootstrap 3 could be different in Bootstrap 4. It is highly recommended to read Bootstrap's migration guide here: https://getbootstrap.com/docs/4.0/migration/. 
+Chameleon 2.0 comes with [Bootstrap 4](https://getbootstrap.com/docs/4.3), an upgraded version of Bootstrap 3 that came with Chameleon 1.x. Class names from Bootstrap 3 could be different in Bootstrap 4. It is highly recommended to read Bootstrap's migration guide here: https://getbootstrap.com/docs/4.0/migration/.
 
 ## Move from Less to SCSS (Sass)
 
@@ -38,7 +52,7 @@ manual rework may be necessary.
 Please be aware that the PHP SCSS compiler is only capable of working with the SCSS language variant. It can not process the
 Sass variant.
 
-##  New way of setting style variables in LocalSettings.php 
+##  New way of setting style variables in LocalSettings.php
 
 **Configuration variable name change:**
 `$egChameleonExternalLessVariables` -> `$egChameleonExternalStyleVariables`
@@ -46,7 +60,7 @@ Sass variant.
 **Using sass variables instead of less variables:**
 OLD style (1.x) example:
 ```
-$egChameleonExternalLessVariables = array(    
+$egChameleonExternalLessVariables = array(
     'font-size-base' 	=> '1rem',
     'font-size-h1' 		=> 'floor((@font-size-base * 2))', 		// originally 36px
     'font-size-h2' 		=> 'floor((@font-size-base * 1.7))',	// originally 30px
@@ -130,4 +144,3 @@ Finally the MediaWiki IRC channel (Server: [libera.chat][irc], Channel: #mediawi
 [chameleon-talk]: https://www.mediawiki.org/wiki/Skin_talk:Chameleon
 [mw-mail]: https://www.mediawiki.org/wiki/Special:EmailUser/F.trott
 [irc]: https://web.libera.chat/?channel=#mediawiki
-

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 ## Release Notes
 
+### Chameleon 6.0.0
+
+Under development.
+
+* Raised minimum MediaWiki version from 1.39 to 1.43
+* Raised minimum PHP version from 8.0 to 8.1
+* Raised minimum Bootstrap extension version from 5.0 to 6.0
+* Added initial Bootstrap 5.3.8 compatibility (thanks @malberts)
+
 ### Chameleon 5.0.2
 
 Released on November 14, 2025.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -322,7 +322,7 @@ Changes:
   registration with [translatewiki](https://translatewiki.net)
 * Improve documentation
 * Replace [jquery-sticky](https://github.com/garand/sticky) by
-  [sticky-kit](http://leafo.net/sticky-kit/)
+  [sticky-kit](https://leafo.net/sticky-kit/)
 * Use sticky for the navbar of the fixedhead layout
 * NavbarHorizontal: Allow custom types and classes for Navbar elements
 * PersonalTools: Add attribute *hideNewtalkNotifier*

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@ Useful optional parameters:
 ```
 
 To test against an external HTML validation service
-(http://validator.w3.org/check) set the `USE_EXTERNAL_HTML_VALIDATOR` setting to
+(https://validator.w3.org/check) set the `USE_EXTERNAL_HTML_VALIDATOR` setting to
 `true` in `phpunit.xml.dist`. Please be careful with their resources and use
 this setting sparingly. If you do this, you may also want to set
 `printerClass="Skins\Chameleon\Tests\Util\ColoringTextUIResultPrinter"` as an
@@ -33,7 +33,7 @@ Yes, really.
 Some features are hard to test automatically and (at least for the moment) have
 to be tested manually. This mostly concerns styling, where it is hard to specify
 test results in a way that CI testing would pick up on failures (and more
-importantly let deviations irrelevant for the test objective pass). 
+importantly let deviations irrelevant for the test objective pass).
 
 Testing of the Chameleon styling is done in a two-dimensional test
 space, the dimensions being
@@ -111,6 +111,3 @@ proposed screen widths are therefore:
 | Definition list             |--------|--------|--------|--------|--------|
 | Indenting                   |--------|--------|--------|--------|--------|
 | TODO: ... (see e.g. https://www.mediawiki.org/wiki/Help:Advanced_editing)
-
-
-

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -323,7 +323,7 @@ Some examples are provided below:
  $enable-pointer-cursor-for-buttons                    | 1
  $enable-prefers-reduced-motion-media-query            | 1
  $enable-print-styles                                  | 1
- $enable-responsive-font-sizes                         | 1
+ $enable-responsive-font-sizes                         | _Removed in Bootstrap 5 - RFS is always enabled_
  $enable-rounded                                       | 1
  $enable-shadows                                       | 1
  $enable-transitions                                   | 1
@@ -1427,7 +1427,7 @@ Some examples are provided below:
  $input-font-size-sm                                   | 0.875rem
  $input-font-weight                                    | 400
  $input-group-addon-bg                                 | #e9ecef
- $input-group-addon-border-color                       | #ced4da
+ $input-group-addon-border-color                       | _Removed in Bootstrap 5 - use `$input-border-color`_
  $input-group-addon-color                              | #495057
  $input-height                                         | calc(1.5em + 0.75rem + 2px)
  $input-height-border                                  | 2px

--- a/layouts/standard.xml
+++ b/layouts/standard.xml
@@ -30,17 +30,17 @@ with this program. If not, see <http://www.gnu.org/licenses/>.
 				<component type="Logo" addLink="yes"/>
 			</cell>
 
-			<cell class="ml-auto col-12 col-cmln">
+			<cell class="ms-auto col-12 col-cmln">
 
 				<row>
 					<cell>
-						<component type="PersonalTools" hideNewtalkNotifier="yes" class="pull-right"/>
+						<component type="PersonalTools" hideNewtalkNotifier="yes" class="float-end"/>
 					</cell>
 				</row>
 
 				<row>
 					<cell>
-						<component type="SearchBar" buttons="go" class="pull-right"/>
+						<component type="SearchBar" buttons="go" class="float-end"/>
 					</cell>
 				</row>
 

--- a/resources/js/Components/toc.js
+++ b/resources/js/Components/toc.js
@@ -61,7 +61,10 @@
 			targetLink = $( '.chameleon-toc a[href="' + hash + '"]' );
 		}
 		if ( targetLink.length !== 0 ) {
-			targetLink.parents( '.nav.collapse' ).collapse('show');
+			targetLink.parents( '.nav.collapse' ).each( function () {
+				var collapseInstance = bootstrap.Collapse.getOrCreateInstance( this );
+				collapseInstance.show();
+			} );
 			goToLink( targetLink );
 		}
 	}
@@ -82,7 +85,10 @@
 		// 	offset += stickyNavbar.outerHeight();
 		// }
 
-		$( 'body' ).scrollspy( { target: '.chameleon-toc', offset: offset } );
+		new bootstrap.ScrollSpy( document.body, {
+			target: '.chameleon-toc',
+			offset: offset
+		} );
 	}
 
 	function addScrollspyEvent() {
@@ -131,7 +137,10 @@
 
 	function addToggleButtonClickEvent() {
 		$( '.toclevel-1 .toggle' ).click( function () {
-			$( this ).siblings( 'ul' ).collapse( 'toggle' );
+			$( this ).siblings( 'ul' ).each( function () {
+				var collapseInstance = bootstrap.Collapse.getOrCreateInstance( this );
+				collapseInstance.toggle();
+			} );
 		} );
 	}
 

--- a/resources/styles/Components/MainContent.scss
+++ b/resources/styles/Components/MainContent.scss
@@ -20,7 +20,7 @@
 	}
 
 	.jump-to-nav {
-		@extend .sr-only;
+		@extend .visually-hidden;
 	}
 
 }

--- a/resources/styles/Components/NavbarHorizontal.scss
+++ b/resources/styles/Components/NavbarHorizontal.scss
@@ -56,7 +56,7 @@
 	.navbar-nav {
 
 		&.right {
-			@extend .ml-#{$cmln-navbar-horizontal-collapse-point}-auto;
+			@extend .ms-#{$cmln-navbar-horizontal-collapse-point}-auto;
 			@extend .mt-#{$cmln-navbar-horizontal-collapse-point}-0;
 			@extend .mt-4;
 		}
@@ -112,7 +112,7 @@
 	}
 
 	.navbar-toggler {
-		@extend .ml-auto;
+		@extend .ms-auto;
 
 		.navbar-toggler-text {
 			padding-left: $navbar-toggler-padding-x;
@@ -155,7 +155,7 @@
 	a.navbar-more-tools, a.navbar-usernotloggedin, a.navbar-userloggedin, a.navbar-tool-link, a:visited.navbar-tool-link {
 		    color: $navbar-light-color;
 	}
-	
+
 	.navbar-tool.avatar {
 		background: white;
 		border-radius: 99px;
@@ -167,6 +167,6 @@
 		height: 41px;
 		background-size: contain;
 		background-repeat: no-repeat;
-		background-position: center;		
+		background-position: center;
 	}
 }

--- a/resources/styles/Components/NavbarHorizontal.scss
+++ b/resources/styles/Components/NavbarHorizontal.scss
@@ -146,7 +146,8 @@
 			//@extend .btn-#{$cmln-search-bar-btn-color}; // FIXME: Should this be ".btn-secondary"? Or some self-defined button style?
 			color: $navbar-light-color;
 
-			@include hover-focus {
+			&:hover,
+			&:focus {
 				color: $navbar-light-hover-color;
 			}
 		}

--- a/resources/styles/Components/SearchBar.scss
+++ b/resources/styles/Components/SearchBar.scss
@@ -20,13 +20,13 @@
 		@extend .btn-#{$cmln-search-bar-btn-color}; // FIXME: Should this be ".btn-secondary"? Or some self-defined button style?
 
 		border: {
-			top-color: $input-group-addon-border-color;
-			bottom-color: $input-group-addon-border-color;
+			top-color: $input-border-color;
+			bottom-color: $input-border-color;
 			left-width: 0;
 		}
 
 		&:last-child {
-			border-right-color: $input-group-addon-border-color;
+			border-right-color: $input-border-color;
 		}
 	}
 }

--- a/resources/styles/_fixes.scss
+++ b/resources/styles/_fixes.scss
@@ -6,14 +6,15 @@
 //
 // @since 2.0
 
+// TODO: BS53
 // Add a max width for container when screen width is xs
-@if $enable-grid-classes {
-	@include media-breakpoint-down(xs) {
-		.container {
-			@include make-container-max-widths((xs: map_get($container-max-widths, sm)), $grid-breakpoints);
-		}
-	}
-}
+//@if $enable-grid-classes {
+//	@include media-breakpoint-down(xs) {
+//		.container {
+//			@include make-container-max-widths((xs: map_get($container-max-widths, sm)), $grid-breakpoints);
+//		}
+//	}
+//}
 
 // Put the font setting on the :before pseudo element, not on the element itself
 // Do not set the line-height on the element

--- a/resources/styles/_mixins.scss
+++ b/resources/styles/_mixins.scss
@@ -42,7 +42,7 @@
 	background-color: transparent; // Remove the gray background on active links in IE 10.
 	-webkit-text-decoration-skip: objects; // Remove gaps in links underline in iOS 8+ and Safari 8+.
 
-	@include hover {
+	&:hover {
 		color: $hover-color;
 		text-decoration: $hover-decoration;
 	}

--- a/resources/styles/_mixins4.scss
+++ b/resources/styles/_mixins4.scss
@@ -1,0 +1,24 @@
+//
+// Deprecated Bootstrap 4 mixins
+//
+// TODO: Update Chameleon to not use these mixins.
+
+// For each breakpoint, define the maximum width of the container in a media query
+@mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
+	@each $breakpoint, $container-max-width in $max-widths {
+		@include media-breakpoint-up($breakpoint, $breakpoints) {
+			max-width: $container-max-width;
+		}
+	}
+}
+
+@mixin hover() {
+	&:hover { @content; }
+}
+
+@mixin hover-focus() {
+	&:hover,
+	&:focus {
+		@content;
+	}
+}

--- a/resources/styles/_mixins4.scss
+++ b/resources/styles/_mixins4.scss
@@ -3,14 +3,15 @@
 //
 // TODO: Update Chameleon to not use these mixins.
 
+// TODO: BS53
 // For each breakpoint, define the maximum width of the container in a media query
-@mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
-	@each $breakpoint, $container-max-width in $max-widths {
-		@include media-breakpoint-up($breakpoint, $breakpoints) {
-			max-width: $container-max-width;
-		}
-	}
-}
+//@mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
+//	@each $breakpoint, $container-max-width in $max-widths {
+//		@include media-breakpoint-up($breakpoint, $breakpoints) {
+//			max-width: $container-max-width;
+//		}
+//	}
+//}
 
 @mixin hover() {
 	&:hover { @content; }

--- a/resources/styles/_mixins4.scss
+++ b/resources/styles/_mixins4.scss
@@ -1,5 +1,7 @@
 //
-// Deprecated Bootstrap 4 mixins
+// Bootstrap 4 compatibility mixins - deprecated
+// These mixins are no longer provided by Bootstrap 5
+// See: https://getbootstrap.com/docs/5.3/migration/#helpers
 //
 // TODO: Update Chameleon to not use these mixins.
 

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -36,7 +36,7 @@ $cmln-link-format: $link-color none darken($link-color, 0.15) underline !default
 
 $cmln-link-formats: () !default;
 $cmln-link-formats: map_merge((
-	new: theme-color("danger") none darken(theme-color("danger"), 0.15) underline,
+	new: map-get($theme-colors, "danger") none darken(map-get($theme-colors, "danger"), 0.15) underline,
 	stub: $cmln-link-format,
 	extiw: $cmln-link-format,
 	external: $cmln-link-format,
@@ -201,8 +201,8 @@ $thumbnail-caption-padding: 3px;
 // (this value should be less than the navbar-height)
 //$navbar-logo-height: .9 * $navbar-height;
 //
-$navbar-user-loggedin: theme-color("primary");
+$navbar-user-loggedin: map-get($theme-colors, "primary");
 $navbar-user-not-loggedin: $navbar-light-disabled-color; // FIXME: Fix color
 
-$navbar-newtalk-available: theme-color("primary"); // $brand-primary;
+$navbar-newtalk-available: map-get($theme-colors, "primary"); // $brand-primary;
 $navbar-newtalk-not-available: $navbar-light-disabled-color; // FIXME: Fix color

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -32,31 +32,31 @@ $cmln-grid-breakpoints: (
 $grid-breakpoints: $cmln-grid-breakpoints;
 
 // Global textual link colors.
-$cmln-link-format: $link-color none darken($link-color, 0.15) underline !default;
+$cmln-link-format: $link-color none darken($link-color, 15%) underline !default;
 
 $cmln-link-formats: () !default;
-$cmln-link-formats: map_merge((
-	new: map-get($theme-colors, "danger") none darken(map-get($theme-colors, "danger"), 0.15) underline,
+$cmln-link-formats: map-merge((
+	new: map-get($theme-colors, "danger") none darken(map-get($theme-colors, "danger"), 15%) underline,
 	stub: $cmln-link-format,
 	extiw: $cmln-link-format,
 	external: $cmln-link-format,
 ), $cmln-link-formats);
 
 // PersonalTools
-$cmln-personal-tools-item-margin: map_get( $spacers, 4 ) !default;
+$cmln-personal-tools-item-margin: map-get( $spacers, 4 ) !default;
 
 $cmln-personal-tools-font-size: $font-size-sm !default;
-$cmln-personal-tools-item-margin: map_get( $spacers, 4 ) !default;
+$cmln-personal-tools-item-margin: map-get( $spacers, 4 ) !default;
 
 $cmln-personal-tools-link: $cmln-link-format !default;
-$cmln-personal-tools-link-new: map_get( $cmln-link-formats, "new" ) !default;
+$cmln-personal-tools-link-new: map-get( $cmln-link-formats, "new" ) !default;
 
 // PageTools
 $cmln-page-tools-font-size: $font-size-sm !default;
-$cmln-page-tools-item-margin: map_get( $spacers, 4 ) !default;
+$cmln-page-tools-item-margin: map-get( $spacers, 4 ) !default;
 
 $cmln-page-tools-link: $cmln-link-format !default;
-$cmln-page-tools-link-new: map_get( $cmln-link-formats, "new" ) !default;
+$cmln-page-tools-link-new: map-get( $cmln-link-formats, "new" ) !default;
 
 // SearchBar
 $cmln-search-bar-collapse-point: cmln !default;
@@ -72,7 +72,7 @@ $cmln-navbar-logo-height: 2 * $nav-link-padding-y + $font-size-base + $navbar-pa
 $cmln-navbar-horizontal-collapse-point: cmln !default;
 
 // Icon defaults
-$cmln-icon-margin: map_get( $spacers, 2 ) !default;
+$cmln-icon-margin: map-get( $spacers, 2 ) !default;
 
 $cmln-icons: () !default;
 $cmln-icons: map-merge((
@@ -181,9 +181,9 @@ $cmln-first-heading-underline-color: $hr-border-color !default;
 $cmln-first-heading-margin-bottom: $hr-margin-y !default;
 
 $cmln-toc-title-font-size: $font-size-lg !default;
-$cmln-toc-group-margin-y: map_get($spacers, 1) !default;
-$cmln-toc-subgroup-margin-left: map_get($spacers, 2) !default;
-$cmln-toc-entry-number-padding-right: map_get($spacers, 2) !default;
+$cmln-toc-group-margin-y: map-get($spacers, 1) !default;
+$cmln-toc-subgroup-margin-left: map-get($spacers, 2) !default;
+$cmln-toc-entry-number-padding-right: map-get($spacers, 2) !default;
 
 // list parameters
 $list-bullet-size: 0.5 * $font-size-base;

--- a/resources/styles/chameleon.scss
+++ b/resources/styles/chameleon.scss
@@ -8,6 +8,7 @@
 
 @import "functions";
 // @import "variables"; // imported at the correct position in SetupAfterCache.php
+@import "mixins4";
 @import "mixins";
 @import "mediawiki.legacy.shared";
 @import "utilities";

--- a/resources/styles/themes/_light.scss
+++ b/resources/styles/themes/_light.scss
@@ -118,13 +118,13 @@ $h6-font-size:                $font-size-base * 1.0 !default;
 // Links
 $link-color: $cobalt;
 $cmln-link-formats: (
-	new: ('color': $burgundy, 'hover-color': darken($burgundy, 0.15)),
+	new: ('color': $burgundy, 'hover-color': darken($burgundy, 15%)),
 );
 
 // Navbar
 $navbar-light-color:                $chambray !default; // cmln: improved contrast
-$navbar-light-hover-color:          darken($navbar-light-color, 0.15) !default;
-$navbar-light-active-color:         darken($navbar-light-color, 0.3) !default;
+$navbar-light-hover-color:          darken($navbar-light-color, 15%) !default;
+$navbar-light-active-color:         darken($navbar-light-color, 30%) !default;
 $navbar-light-disabled-color:       fade_out($navbar-light-color, 0.3) !default;
 $navbar-light-toggler-border-color: fade_out($navbar-light-color, 0.5) !default;
 
@@ -139,10 +139,10 @@ $body-bg:                   $white !default;
 $body-color:                $gray-900 !default;
 
 // PersonalTools
-$cmln-personal-tools-link-new: ('color': $gray-600, 'hover-color': darken($gray-600, 0.15)) !default;
+$cmln-personal-tools-link-new: ('color': $gray-600, 'hover-color': darken($gray-600, 15%)) !default;
 
 // PageTools
-$cmln-page-tools-link-new: ('color': $gray-600, 'hover-color': darken($gray-600, 0.15)) !default;
+$cmln-page-tools-link-new: ('color': $gray-600, 'hover-color': darken($gray-600, 15%)) !default;
 
 //$enable-caret:                                true !default;
 //$enable-rounded:                              true !default;
@@ -154,6 +154,6 @@ $cmln-page-tools-link-new: ('color': $gray-600, 'hover-color': darken($gray-600,
 //$enable-grid-classes:                         true !default;
 //$enable-pointer-cursor-for-buttons:           true !default;
 //$enable-print-styles:                         true !default;
-$enable-responsive-font-sizes:                true !default;
+//$enable-responsive-font-sizes:                true !default; // Removed in Bootstrap 5 - RFS is always enabled
 //$enable-validation-icons:                     true !default;
 //$enable-deprecation-messages:                 true !default;

--- a/resources/styles/utilities/_float.scss
+++ b/resources/styles/utilities/_float.scss
@@ -6,5 +6,5 @@
 //
 // @since 2.0
 
-.pull-left { @include float-left; }
-.pull-right { @include float-right; }
+.pull-left { @extend .float-start; }
+.pull-right { @extend .float-end; }

--- a/resources/styles/utilities/_float.scss
+++ b/resources/styles/utilities/_float.scss
@@ -6,5 +6,7 @@
 //
 // @since 2.0
 
+// Bootstrap 4 compatibility - deprecated, will be removed in v7.0
+// See: https://getbootstrap.com/docs/5.3/migration/#utilities
 .pull-left { @extend .float-start; }
 .pull-right { @extend .float-end; }

--- a/resources/styles/utilities/_widths.scss
+++ b/resources/styles/utilities/_widths.scss
@@ -9,10 +9,10 @@
 
 
 @function max-width( $breakpoint ) {
-	@return #{ "max-width: " + ( map_get( $grid-breakpoints, $breakpoint ) - 0.02px ) };
+	@return #{ "max-width: " + ( map-get( $grid-breakpoints, $breakpoint ) - 0.02px ) };
 }
 
 @function min-width( $breakpoint ) {
-	@return #{ "min-width: "+ map_get( $grid-breakpoints, $breakpoint ) };
+	@return #{ "min-width: "+ map-get( $grid-breakpoints, $breakpoint ) };
 }
 

--- a/skin.json
+++ b/skin.json
@@ -8,14 +8,14 @@
 		"Morne Alberts",
 		"[https://www.EntropyWins.wtf/mediawiki Jeroen De Dauw]"
 	],
-	"version": "5.0.2",
+	"version": "6.0.0-dev",
 	"url": "https://www.mediawiki.org/wiki/Skin:Chameleon",
 	"descriptionmsg": "chameleon-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
+		"MediaWiki": ">= 1.43.0",
 		"extensions": {
-			"Bootstrap": "~5.0"
+			"Bootstrap": "~6.0"
 		}
 	},
 	"AutoloadNamespaces": {

--- a/src/Chameleon.php
+++ b/src/Chameleon.php
@@ -176,12 +176,3 @@ class Chameleon extends SkinTemplate {
 		return $GLOBALS[ 'egChameleonThemeFile' ];
 	}
 }
-
-// Support MediaWiki 1.39 and 1.44. Remove this when dropping support for 1.39.
-// Aliases as per https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1124809
-if ( version_compare( MW_VERSION, '1.44', '>=' ) ) {
-	class_alias( \MediaWiki\Html\Html::class, 'Html' );
-	class_alias( \MediaWiki\Linker\Linker::class, 'Linker' );
-	class_alias( \MediaWiki\Request\FauxRequest::class, 'FauxRequest' );
-	class_alias( \MediaWiki\Title\Title::class, 'Title' );
-}

--- a/src/Components/Container.php
+++ b/src/Components/Container.php
@@ -26,6 +26,7 @@
 
 namespace Skins\Chameleon\Components;
 
+use MediaWiki\Html\Html;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -57,7 +58,7 @@ class Container extends Structure {
 			$attribs['id'] = IdRegistry::getRegistry()->getId( $id );
 		}
 
-		$ret = $this->indent() . \Html::openElement( 'div', $attribs );
+		$ret = $this->indent() . Html::openElement( 'div', $attribs );
 		$this->indent( 1 );
 
 		$ret .= parent::getHtml();

--- a/src/Components/Logo.php
+++ b/src/Components/Logo.php
@@ -26,7 +26,7 @@
 
 namespace Skins\Chameleon\Components;
 
-use Linker;
+use MediaWiki\Linker\Linker;
 use Skins\Chameleon\IdRegistry;
 
 /**

--- a/src/Components/Menu.php
+++ b/src/Components/Menu.php
@@ -57,7 +57,7 @@ class Menu extends Component {
 
 			// @codingStandardsIgnoreStart
 			if ( $depth === 1 && !empty( $subitems ) ) {
-				return "<div class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle $class\" href=\"#\"  data-toggle=\"dropdown\"  data-boundary=\"viewport\">$text</a>$subitems</div>";
+				return "<div class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle $class\" href=\"#\"  data-bs-toggle=\"dropdown\"  data-bs-boundary=\"viewport\">$text</a>$subitems</div>";
 			} else {
 				return "<div class=\"nav-item\"><a class=\"nav-link $class\"  href=\"$href\">$text</a>$subitems</div>";
 			}

--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -213,8 +213,8 @@ class NavMenu extends Component {
 				[
 					'href' => '#',
 					'class' => 'nav-link dropdown-toggle ' . $menuId . '-toggle',
-					'data-toggle' => 'dropdown',
-					'data-boundary' => 'viewport',
+					'data-bs-toggle' => 'dropdown',
+					'data-bs-boundary' => 'viewport',
 					'title' => Linker::titleAttrib( $menuId ),
 				],
 				htmlspecialchars( $menuDescription['header'] ) );

--- a/src/Components/NavMenu.php
+++ b/src/Components/NavMenu.php
@@ -26,8 +26,9 @@
 
 namespace Skins\Chameleon\Components;
 
-use Linker;
-use Sanitizer;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
+use MediaWiki\Parser\Sanitizer;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -178,11 +179,11 @@ class NavMenu extends Component {
 	protected function buildDropdownMenuStub( $menuDescription ) {
 		$menuId = $menuDescription['id'];
 
-		return $this->indent() . \Html::rawElement( 'div',
+		return $this->indent() . Html::rawElement( 'div',
 				[
 					'class' => 'nav-item ' . $menuId . '-dropdown',
 				],
-				\Html::rawElement( 'a',
+				Html::rawElement( 'a',
 					[
 						'href' => '#',
 						'class' => 'nav-link ' . $menuId . '-toggle',
@@ -202,14 +203,14 @@ class NavMenu extends Component {
 		$menuId = $menuDescription['id'];
 
 		// open list item containing the dropdown
-		$ret = $this->indent() . \Html::openElement( 'div',
+		$ret = $this->indent() . Html::openElement( 'div',
 				[
 					'class' => 'nav-item dropdown ' . $menuId . '-dropdown',
 				] );
 
 		// add the dropdown toggle
 		$ret .= $this->indent( 1 ) .
-			\Html::rawElement( 'a',
+			Html::rawElement( 'a',
 				[
 					'href' => '#',
 					'class' => 'nav-link dropdown-toggle ' . $menuId . '-toggle',
@@ -221,7 +222,7 @@ class NavMenu extends Component {
 
 		// open list of dropdown menu items
 		$ret .=
-			$this->indent() . \Html::openElement( 'div',
+			$this->indent() . Html::openElement( 'div',
 				[
 					'class' => 'dropdown-menu ' . $menuId,
 					'id'    => IdRegistry::getRegistry()->getId( $menuId ),

--- a/src/Components/NavbarHorizontal.php
+++ b/src/Components/NavbarHorizontal.php
@@ -259,7 +259,7 @@ class NavbarHorizontal extends Component {
 		$id = IdRegistry::getRegistry()->getId();
 
 		return $this->indent() .
-			'<button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#' . $id .
+			'<button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#' . $id .
 			'">' . $this->getTogglerText() . '</button>' .
 			IdRegistry::getRegistry()->element( 'div', [ 'class' => 'collapse navbar-collapse',
 			'id' => $id ], $tail, $this->indent() );

--- a/src/Components/NavbarHorizontal.php
+++ b/src/Components/NavbarHorizontal.php
@@ -27,6 +27,7 @@
 namespace Skins\Chameleon\Components;
 
 use DOMElement;
+use MediaWiki\Html\Html;
 use Skins\Chameleon\IdRegistry;
 
 /**
@@ -92,7 +93,7 @@ class NavbarHorizontal extends Component {
 
 		$openingTags =
 			$this->indent() . '<!-- navigation bar -->' .
-			$this->indent() . \Html::openElement( 'nav', [
+			$this->indent() . Html::openElement( 'nav', [
 					'class' => $class,
 					'role'  => 'navigation',
 					// FIXME: ID to be repeated in classes
@@ -279,7 +280,7 @@ class NavbarHorizontal extends Component {
 		if ( !filter_var( $this->getAttribute( 'showTogglerText', 'false' ), FILTER_VALIDATE_BOOLEAN ) ) {
 			return '';
 		}
-		return \Html::rawElement( 'span', [ 'class' => 'navbar-toggler-text' ],
+		return Html::rawElement( 'span', [ 'class' => 'navbar-toggler-text' ],
 			$this->getSkinTemplate()->getMsg( 'chameleon-toggler' )->escaped() );
 	}
 

--- a/src/Components/NavbarHorizontal/LangLinks.php
+++ b/src/Components/NavbarHorizontal/LangLinks.php
@@ -108,8 +108,8 @@ class LangLinks extends Component {
 				[
 					'href' => '#',
 					'class' => 'nav-link dropdown-toggle p-lang-toggle',
-					'data-toggle' => 'dropdown',
-					'data-boundary' => 'viewport'
+					'data-bs-toggle' => 'dropdown',
+					'data-bs-boundary' => 'viewport'
 				],
 				$this->getSkinTemplate()->getMsg( $labelMsg )->escaped()
 			);

--- a/src/Components/NavbarHorizontal/PageTools.php
+++ b/src/Components/NavbarHorizontal/PageTools.php
@@ -200,8 +200,8 @@ class PageTools extends Component {
 		}
 
 		return $this->indent() . \Html::rawElement( 'div', [ 'class' => 'navbar-tool dropdown' ],
-				$this->indent( 1 ) . \Html::rawElement( 'a', [ 'data-toggle' => 'dropdown',
-				'data-boundary' => 'viewport', 'class' => 'navbar-more-tools', 'href' => '#',
+				$this->indent( 1 ) . \Html::rawElement( 'a', [ 'data-bs-toggle' => 'dropdown',
+				'data-bs-boundary' => 'viewport', 'class' => 'navbar-more-tools', 'href' => '#',
 				'title' => $this->getSkinTemplate()->getMsg( 'specialpages-group-pagetools' )->text() ] ) .
 				$pageToolsHtml . $this->indent( -1 )
 			);

--- a/src/Components/NavbarHorizontal/PageTools.php
+++ b/src/Components/NavbarHorizontal/PageTools.php
@@ -26,6 +26,7 @@
 
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
+use MediaWiki\Html\Html;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\Components\PageTools as GenericPageTools;
 
@@ -57,7 +58,7 @@ class PageTools extends Component {
 		if ( $actionButtonHtmlFragments !== [] || $pageToolsHtml !== '' ) {
 
 			return $this->indent() . '<!-- page tools -->' .
-				$this->indent() . \Html::rawElement( 'div', [ 'class' => 'navbar-tools navbar-nav ' .
+				$this->indent() . Html::rawElement( 'div', [ 'class' => 'navbar-tools navbar-nav ' .
 					$this->getClassString() ],
 					implode( $actionButtonHtmlFragments ) .
 					$pageToolsHtml .
@@ -199,8 +200,8 @@ class PageTools extends Component {
 			return '';
 		}
 
-		return $this->indent() . \Html::rawElement( 'div', [ 'class' => 'navbar-tool dropdown' ],
-				$this->indent( 1 ) . \Html::rawElement( 'a', [ 'data-bs-toggle' => 'dropdown',
+		return $this->indent() . Html::rawElement( 'div', [ 'class' => 'navbar-tool dropdown' ],
+				$this->indent( 1 ) . Html::rawElement( 'a', [ 'data-bs-toggle' => 'dropdown',
 				'data-bs-boundary' => 'viewport', 'class' => 'navbar-more-tools', 'href' => '#',
 				'title' => $this->getSkinTemplate()->getMsg( 'specialpages-group-pagetools' )->text() ] ) .
 				$pageToolsHtml . $this->indent( -1 )

--- a/src/Components/NavbarHorizontal/PersonalTools.php
+++ b/src/Components/NavbarHorizontal/PersonalTools.php
@@ -254,7 +254,7 @@ class PersonalTools extends Component {
 
 		$attr = [
 			'class' => $toolsClass,
-			'href' => '#', 'data-toggle' => 'dropdown', 'data-boundary' => 'viewport',
+			'href' => '#', 'data-bs-toggle' => 'dropdown', 'data-bs-boundary' => 'viewport',
 			'title' => $toolsLinkText
 		];
 

--- a/src/Components/NavbarHorizontal/PersonalTools.php
+++ b/src/Components/NavbarHorizontal/PersonalTools.php
@@ -26,7 +26,9 @@
 
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\IdRegistry;
 
@@ -104,11 +106,11 @@ class PersonalTools extends Component {
 		return $echoHtml .
 			$this->indent() . '<!-- personal tools -->' .
 			$this->indent() . '<div class="navbar-tools navbar-nav" >' .
-			$this->indent( 1 ) . \Html::rawElement( 'div',
+			$this->indent( 1 ) . Html::rawElement( 'div',
 				[ 'class' => 'navbar-tool' . ( !$this->avatarUrl ? '' : ' avatar' ) . ' dropdown' ],
 
 				$this->getDropdownToggle() .
-				$this->indent( 1 ) . \Html::rawElement( 'div',
+				$this->indent( 1 ) . Html::rawElement( 'div',
 					[ 'class' => 'p-personal-tools dropdown-menu' ],
 					$this->getToolsHtml( $tools ) . $this->indent() ) .
 				$this->indent( -1 )
@@ -294,7 +296,7 @@ class PersonalTools extends Component {
 		$imagePage = null;
 		$username = $user->getName();
 		foreach ( $imageExt as $ext ) {
-			$title = \Title::makeTitleSafe( NS_FILE, "$username.$ext" );
+			$title = Title::makeTitleSafe( NS_FILE, "$username.$ext" );
 			if ( $title && $title->isKnown() ) {
 				$imagePage = new \WikiFilePage( $title );
 				break;

--- a/src/Components/NavbarHorizontal/Toolbox.php
+++ b/src/Components/NavbarHorizontal/Toolbox.php
@@ -109,7 +109,7 @@ class Toolbox extends Component {
 		$trigger = $this->indent( 1 ) . IdRegistry::getRegistry()->element(
 				'a',
 				[ 'href' => '#', 'class' => 'nav-link dropdown-toggle p-tb-toggle',
-                  'data-toggle' => 'dropdown', 'data-boundary' => 'viewport',
+                  'data-bs-toggle' => 'dropdown', 'data-bs-boundary' => 'viewport',
                   'title' => Linker::titleAttrib( 'p-tb' ), ],
 				$this->getSkinTemplate()->getMsg( $labelMsg )->escaped()
 			);

--- a/src/Components/NavbarHorizontal/Toolbox.php
+++ b/src/Components/NavbarHorizontal/Toolbox.php
@@ -26,8 +26,7 @@
 
 namespace Skins\Chameleon\Components\NavbarHorizontal;
 
-use Hooks;
-use Linker;
+use MediaWiki\Linker\Linker;
 use Skins\Chameleon\Components\Component;
 use Skins\Chameleon\IdRegistry;
 

--- a/src/Components/NewtalkNotifier.php
+++ b/src/Components/NewtalkNotifier.php
@@ -26,6 +26,8 @@
 
 namespace Skins\Chameleon\Components;
 
+use MediaWiki\Html\Html;
+
 /**
  * The NewtalkNotifier class.
  *
@@ -49,7 +51,7 @@ class NewtalkNotifier extends Component {
 		if ( array_key_exists( 'newtalk', $data ) && $data[ 'newtalk' ] ) {
 			return $this->indent() .
 				'<!-- new talk notifier message to a user about new messages on their talkpage -->' .
-			  $this->indent() . \Html::rawElement( 'div', [ 'class' => 'usermessage ' .
+			  $this->indent() . Html::rawElement( 'div', [ 'class' => 'usermessage ' .
 				$this->getClassString() ], $data[ 'newtalk' ] );
 		} else {
 			return '';

--- a/src/Components/SearchBar.php
+++ b/src/Components/SearchBar.php
@@ -26,7 +26,8 @@
 
 namespace Skins\Chameleon\Components;
 
-use Linker;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
 use Skin;
 use Skins\Chameleon\IdRegistry;
 
@@ -48,7 +49,7 @@ class SearchBar extends Component {
 	 * @throws \MWException
 	 */
 	public function getHtml() {
-		$attribsSearchFormWrapper = \Html::expandAttributes( [
+		$attribsSearchFormWrapper = Html::expandAttributes( [
 				'id'    => IdRegistry::getRegistry()->getId( 'p-search' ),
 				'class' => 'p-search ' . $this->getClassString(),
 				'role'  => 'search',
@@ -57,7 +58,7 @@ class SearchBar extends Component {
 
 		$tooltipSearchFormWrapper = Linker::tooltip( 'p-search' );
 
-		$attribsSearchForm = \Html::expandAttributes( [
+		$attribsSearchForm = Html::expandAttributes( [
 				'id'    => IdRegistry::getRegistry()->getId( 'searchform' ),
 				'class' => 'mw-search',
 				'action' => $this->getSkinTemplate()->data[ 'wgScript' ],
@@ -158,7 +159,7 @@ class SearchBar extends Component {
 				Linker::tooltipAndAccesskeyAttribs( "search-$nameAttr" )
 			);
 
-			return $this->indent() . \Html::rawElement( 'button', $buttonAttrs );
+			return $this->indent() . Html::rawElement( 'button', $buttonAttrs );
 		}
 
 		return '';

--- a/src/Hooks/ResourceLoaderRegisterModules.php
+++ b/src/Hooks/ResourceLoaderRegisterModules.php
@@ -74,19 +74,12 @@ class ResourceLoaderRegisterModules {
 			'elements',
 			'content-links',
 			'content-media',
-			'interface-message-box',
 			'interface-category',
 			'content-tables',
 			'i18n-ordered-lists',
-			'i18n-all-lists-margins',
 			'i18n-headings',
 			'toc'
 		];
-
-		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
-			$removed = [ 'i18n-all-lists-margins', 'interface-message-box' ];
-			$features = array_values( array_diff( $features, $removed ) );
-		}
 
 		if ( $this->configuration['egChameleonEnableExternalLinkIcons'] === true ) {
 			$features[] = 'content-links-external';

--- a/src/IdRegistry.php
+++ b/src/IdRegistry.php
@@ -26,6 +26,8 @@
 
 namespace Skins\Chameleon;
 
+use MediaWiki\Html\Html;
+
 /**
  * Class IdRegistry provides a registry and access methods to ensure each id is only used once per
  * HTML page.
@@ -93,7 +95,7 @@ class IdRegistry {
 	public function openElement( $tag, $attributes = [] ) {
 		$attributes = $this->getAttributesWithUniqueId( $attributes );
 
-		return \Html::openElement( $tag, $attributes );
+		return Html::openElement( $tag, $attributes );
 	}
 
 	/**
@@ -111,7 +113,7 @@ class IdRegistry {
 	public function element( $tag, $attributes = [], $contents = '', $indent = '' ) {
 		$attributes = $this->getAttributesWithUniqueId( $attributes );
 
-		return $indent . \Html::rawElement( $tag, $attributes, $contents . $indent );
+		return $indent . Html::rawElement( $tag, $attributes, $contents . $indent );
 	}
 
 	/**

--- a/src/Menu/MenuFromLines.php
+++ b/src/Menu/MenuFromLines.php
@@ -27,7 +27,7 @@
 namespace Skins\Chameleon\Menu;
 
 use MediaWiki\MediaWikiServices;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * Class MenuFromLines

--- a/tests/phpunit/Unit/Hooks/ResourceLoaderRegisterModulesTest.php
+++ b/tests/phpunit/Unit/Hooks/ResourceLoaderRegisterModulesTest.php
@@ -137,19 +137,12 @@ class ResourceLoaderRegisterModulesTest extends TestCase {
 			'elements',
 			'content-links',
 			'content-media',
-			'interface-message-box',
 			'interface-category',
 			'content-tables',
 			'i18n-ordered-lists',
-			'i18n-all-lists-margins',
 			'i18n-headings',
 			'toc'
 		];
-
-		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
-			$removed = [ 'i18n-all-lists-margins', 'interface-message-box' ];
-			$features = array_values( array_diff( $features, $removed ) );
-		}
 
 		return $features;
 	}

--- a/tests/phpunit/Util/MockupFactory.php
+++ b/tests/phpunit/Util/MockupFactory.php
@@ -123,13 +123,6 @@ class MockupFactory {
 			->method( 'getSidebar' )
 			->will( $this->testCase->returnValue( [] ) );
 
-
-		if ( version_compare( MW_VERSION, '1.41', '<' ) ) {
-			$chameleonTemplate->expects( $this->testCase->any() )
-				->method( 'getToolbox' )
-				->will( $this->testCase->returnValue( [] ) );
-		}
-
 		$chameleonTemplate->expects( $this->testCase->any() )
 			->method( 'getPersonalTools' )
 			->will( $this->testCase->returnValue( [

--- a/tests/phpunit/Util/MockupFactory.php
+++ b/tests/phpunit/Util/MockupFactory.php
@@ -25,7 +25,8 @@
 namespace Skins\Chameleon\Tests\Util;
 
 use Config;
-use FauxRequest;
+use MediaWiki\Request\FauxRequest;
+use MediaWiki\Title\Title;
 use Message;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -34,7 +35,6 @@ use Skins\Chameleon\ChameleonTemplate;
 use Skins\Chameleon\ComponentFactory;
 use Skins\Chameleon\Components\Component;
 use stdClass;
-use Title;
 use User;
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/chameleon/issues/385

Bootstrap extension has been updated to Bootstrap library 5.3.8: https://github.com/ProfessionalWiki/Bootstrap/pull/82

<img width="1920" height="10734" alt="image" src="https://github.com/user-attachments/assets/67c01684-e7fc-4a84-b8ad-d68061c32839" />

