### PR TITLE
Disable Composer audit.block-insecure in CI for MW < 1.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v21
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v22
 
       - name: Cache Composer cache
         uses: actions/cache@v4

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -e
 
 MW_BRANCH=$1
 EXTENSION_NAME=$2
@@ -9,6 +10,11 @@ tar -zxf $MW_BRANCH.tar.gz
 mv mediawiki-$MW_BRANCH mediawiki
 
 cd mediawiki
+
+# TODO: Remove once MW < 1.43 is dropped from the matrix.
+# Mirrors the upstream fix in MW REL1_43+ / master (mediawiki commit
+# ef90ede, Phab T416518), which older branches never received.
+composer config audit.block-insecure false
 
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser


### PR DESCRIPTION
## Summary

- CI has been failing on all matrix jobs since early 2026 because `composer update` refuses to install the phpunit versions pinned by MediaWiki REL1_39/41/42 — they're flagged by advisory `PKSA-z3gr-8qht-p93v`.
- Upstream MediaWiki fixed this on REL1_43+ and master (commit [ef90ede](https://github.com/wikimedia/mediawiki/commit/ef90ede), Phab [T416518](https://phabricator.wikimedia.org/T416518)) by setting `"audit": {"block-insecure": false}` in composer.json. Older branches did not receive the backport.
- Mirror that switch from the CI side via `composer config audit.block-insecure false` before `composer update`, so older MW versions can install again. No-op on REL1_43/master where the flag is already set upstream.
- TODO in the workflow flags this for removal once MW < 1.43 is dropped from the matrix.

## Test plan

- [ ] CI passes on this PR for REL1_39, REL1_41, REL1_42, REL1_43, and master