### PR TITLE
Add MW REL1_44 and REL1_45 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,14 @@ jobs:
           - mw: 'REL1_43'
             php: 8.3
             experimental: false
-          - mw: 'master'
+          - mw: 'REL1_44'
+            php: 8.3
+            experimental: false
+          - mw: 'REL1_45'
             php: 8.4
+            experimental: false
+          - mw: 'master'
+            php: 8.5
             experimental: true
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds stable MW REL1_44 (PHP 8.3) and REL1_45 (PHP 8.4) to the CI matrix alongside the existing LTS (REL1_43).
- Bumps the experimental `master` entry from PHP 8.4 to PHP 8.5 for early-warning signal. Upstream MediaWiki has been actively backporting PHP 8.5 compat fixes to REL1_43+ (see the [PHP 8.5 workboard](https://phabricator.wikimedia.org/tag/php_8.5_support/)) but has not yet declared 8.5 officially supported, so keeping this as experimental / `continue-on-error: true` is appropriate.

## Test plan

- [ ] CI passes on this PR for REL1_44 and REL1_45
- [ ] REL1_39, REL1_41, REL1_42, REL1_43 still pass
- [ ] master (now on PHP 8.5) remains allowed-to-fail