### PR TITLE
Bootstrap 5 follow-up fixes: link decoration and dead extension-fix block

### DIFF
--- a/resources/styles/_extensionfixes.scss
+++ b/resources/styles/_extensionfixes.scss
@@ -17,13 +17,6 @@
 	z-index: 1; // FIXME: Was $zindex-navbar-fixed + 1. What was $zindex-navbar-fixed?
 }
 
-// float the VE UI toolbar below a fixed or sticky navbar
-.navbar.navbar-fixed-top, .navbar + .sticky-wrapper {
-	~ * .ve-ui-toolbar-floating > .oo-ui-toolbar-bar {
-		//			transform: translateY($navbar-height);
-	}
-}
-
 /* Extension SemanticMediaWiki */
 .skin-chameleon {
 	.smw-editpage-help, .smw-search-results-prepend {

--- a/resources/styles/_variables.scss
+++ b/resources/styles/_variables.scss
@@ -10,6 +10,10 @@
 // Dark mode is tracked separately in issue #449.
 $enable-dark-mode: false;
 
+// Restore the Bootstrap 4 link-decoration defaults (BS5 flipped to underline).
+$link-decoration: none;
+$link-hover-decoration: underline;
+
 // Variable names should follow the `$component-state-property-size` formula
 // (leaving out inapplicable parts) for consistent naming.
 // Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.


### PR DESCRIPTION
## Summary

Two small post-merge follow-ups to the Bootstrap 5 upgrade in #484, both flagged after the merge during a comparison of the upgraded skin against a Bootstrap 4 production site.

## What changed

1. **Restore the Bootstrap 4 link-decoration defaults.** Bootstrap 5.3 flipped `$link-decoration` from `none` to `underline` and `$link-hover-decoration` from `underline` to `null`. Chameleon never overrode either, so the BS5 upgrade silently added an underline to every `<a>` site-wide and removed the underline-on-hover indicator. Set both back to their BS4 values in `_variables.scss` so links are plain by default and underlined on hover, as they have always been.
2. **Drop an unused `.navbar-fixed-top` compatibility block** from `_extensionfixes.scss`. The block contained only a commented-out `transform` and emitted no CSS. Neither selector half is used internally, and Bootstrap 5 no longer applies the BS4 `.navbar-fixed-top` class anywhere.

## Verification

- SCSS-level: the compiled Bootstrap module now emits `a { text-decoration: none }` and `a:hover { text-decoration: underline }`, matching the Bootstrap 4 baseline. The whole-file diff against `master` is concentrated in `<a>` rules and the consequential removal of redundant `text-decoration: none` overrides in six components (`dropdown`, `buttons`, `list-group`, `nav`, `pagination`, `navbar`) — no unrelated changes.
- Live computed style on `<a>` matches: `text-decoration: none` (normal), `underline` (hover).
- The `.navbar-fixed-top` block change is a pure dead-code removal — the compiled CSS for that selector chain was already empty.

## Awaiting before ready review

A production-representative spot-check (real content, extensions, browser) — for any further visible regressions that this two-fix scope might miss. Until that returns clean, this PR stays in draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
