### PR TITLE
Render the language portlet's SkinAfterPortlet content (Wikibase Edit/Add links)

### DIFF
--- a/resources/styles/Components/NavbarHorizontal.scss
+++ b/resources/styles/Components/NavbarHorizontal.scss
@@ -67,8 +67,11 @@
 			list-style: none;
 			padding-left: 0;
 
-			// Override nav-link styling in case the menu item is in a dropdown
-			& > div > a:first-child:last-child {
+			// Override nav-link styling when the item is in a dropdown. Chameleon's
+			// own menu items are div-wrapped; the SkinAfterPortlet hook may also add
+			// a span-wrapped link here, which the second selector covers.
+			& > div > a:first-child:last-child,
+			& > span > a:first-child:last-child {
 
 				@extend .dropdown-item;
 

--- a/src/Components/NavbarHorizontal/LangLinks.php
+++ b/src/Components/NavbarHorizontal/LangLinks.php
@@ -47,17 +47,21 @@ class LangLinks extends Component {
 	 * @throws \MWException
 	 */
 	public function getHtml() {
-		if ( !$this->hasLangLinks() ) {
+		$afterPortlet = $this->getSkin()->getAfterPortlet( 'lang' );
+
+		if ( !$this->hasLangLinks() && $afterPortlet === '' ) {
 			return '';
 		}
 
 		$introComment = $this->indent() . '<!-- languages -->';
 
+		$listItems = $this->hasLangLinks() ? implode( $this->getLinkListItems() ) : '';
+		$contents = $listItems . $afterPortlet;
+
 		if ( filter_var( $this->getAttribute( 'flatten' ), FILTER_VALIDATE_BOOLEAN ) ) {
-			$languageLinks = implode( $this->getLinkListItems() );
+			$languageLinks = $contents;
 		} else {
-			$languageLinks = $this->wrapDropdownMenu( 'otherlanguages',
-				implode( $this->getLinkListItems() ) );
+			$languageLinks = $this->wrapDropdownMenu( 'otherlanguages', $contents );
 		}
 
 		return $introComment . $languageLinks;

--- a/tests/phpunit/Unit/Components/NavbarHorizontal/LangLinksTest.php
+++ b/tests/phpunit/Unit/Components/NavbarHorizontal/LangLinksTest.php
@@ -24,7 +24,9 @@
 
 namespace Skins\Chameleon\Tests\Unit\Components\NavbarHorizontal;
 
+use Skins\Chameleon\Components\NavbarHorizontal\LangLinks;
 use Skins\Chameleon\Tests\Unit\Components\GenericComponentTestCase;
+use Skins\Chameleon\Tests\Util\MockupFactory;
 
 /**
  * @coversDefaultClass \Skins\Chameleon\Components\NavbarHorizontal\LangLinks
@@ -42,5 +44,27 @@ use Skins\Chameleon\Tests\Unit\Components\GenericComponentTestCase;
 class LangLinksTest extends GenericComponentTestCase {
 
 	protected $classUnderTest = '\Skins\Chameleon\Components\NavbarHorizontal\LangLinks';
+
+	/**
+	 * @covers ::getHtml
+	 */
+	public function testAfterPortletContentIsRenderedWithoutLanguageLinks() {
+		$factory = MockupFactory::makeFactory( $this );
+		$factory->set( 'AfterPortlet',
+			[ 'lang' => '<span class="wbc-editpage">AFTER_PORTLET_MARKER</span>' ] );
+
+		$component = new LangLinks( $factory->getChameleonSkinTemplateStub() );
+
+		$this->assertStringContainsString( 'AFTER_PORTLET_MARKER', $component->getHtml() );
+	}
+
+	/**
+	 * @covers ::getHtml
+	 */
+	public function testGetHtmlIsEmptyWithoutLanguageLinksOrAfterPortletContent() {
+		$component = new LangLinks( MockupFactory::makeFactory( $this )->getChameleonSkinTemplateStub() );
+
+		$this->assertSame( '', $component->getHtml() );
+	}
 
 }

--- a/tests/phpunit/Util/MockupFactory.php
+++ b/tests/phpunit/Util/MockupFactory.php
@@ -270,6 +270,12 @@ class MockupFactory {
 			->method( 'getConfig' )
 			->will( $this->testCase->returnValue( $this->getConfigStub() ) );
 
+		$skin->expects( $this->testCase->any() )
+			->method( 'getAfterPortlet' )
+			->willReturnCallback( function ( string $name ): string {
+				return $this->get( 'AfterPortlet', [] )[ $name ] ?? '';
+			} );
+
 		return $skin;
 	}
 


### PR DESCRIPTION
## Problem

In most skins, Wikibase Client adds an "Edit links" / "Add links" entry to the
"In other languages" menu, linking to the connected repository item so editors
can add or edit interlanguage links. In Chameleon this link never appears.

For #316.

## Cause

`NavbarHorizontal\LangLinks` builds the language menu purely from the
`language_urls` template data and never calls `Skin::getAfterPortlet( 'lang' )`,
so the output of the `SkinAfterPortlet` hook is discarded. That hook is where
Wikibase contributes its link (and where any extension may add to the language
portlet). The contribution is also present when the page has no language links
of its own (the "Add links" case), which the component dropped completely by
returning early.

## Change

- Surface `getAfterPortlet( 'lang' )` in `LangLinks`, including when the page
  has no language links, while still emitting nothing when there is neither a
  list nor a contribution.
- Style the contributed link as a dropdown item: Chameleon wraps its own menu
  items in a `div`, while a `SkinAfterPortlet` contribution arrives in a `span`,
  so the styling rule matches both.

This is generic `SkinAfterPortlet` support for the language portlet, not
Wikibase-specific: the contributed HTML is passed through untouched, so
Wikibase's own link-item JS still enhances the "Add links" link.

## Verification

- Unit test: the after-portlet contribution is rendered even when the page has
  no language links of its own.
- UI (Playwright) against a local Wikibase repository + client: a connected page
  shows the language list followed by "Edit links"; an unconnected page shows
  "Add links".

UI (Playwright), connected page "Berlin":
<img width="1920" height="1080" alt="realistic-berlin-edit-links-master" src="https://github.com/user-attachments/assets/acceb2f1-0b66-428a-96d6-7c8ebbaeec04" />

