### PR TITLE
Fix 5.x CI and test up to MediaWiki 1.45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
           - mw: 'REL1_43'
             php: 8.3
             experimental: false
-          - mw: 'master'
+          - mw: 'REL1_44'
+            php: 8.3
+            experimental: false
+          - mw: 'REL1_45'
             php: 8.4
-            experimental: true
+            experimental: false
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -10,6 +10,10 @@ mv mediawiki-$MW_BRANCH mediawiki
 
 cd mediawiki
 
+# Mirrors the upstream fix in MW REL1_43+ / master (mediawiki commit
+# ef90ede, Phab T416518), which older branches never received.
+composer config audit.block-insecure false
+
 composer install
 php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
 


### PR DESCRIPTION
## Problem

CI on the 5.x line fails before any test runs: MediaWiki core exact-pins
dependencies such as `symfony/yaml 5.4.23`, now flagged by Packagist advisories,
so composer refuses to resolve them and `composer install` aborts.

The matrix also stopped at 1.43.

## Changes

- **`installWiki.sh`:** disable composer's advisory blocking during wiki setup so
  the pinned core dependencies install. Mirrors MediaWiki's REL1_43+ fix (Phab T416518).
- **Matrix:** add MediaWiki 1.44 and 1.45, the newest versions the 5.x line
  supports (core keeps `psr/http-message` on v1 through 1.45). MediaWiki 1.46+/master
  is not covered: the 5.x line pins `psr/http-message: ^1`, incompatible with core's
  move to `2.0`.
