### PR TITLE
Support MediaWiki 1.46

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
           - mw: 'REL1_45'
             php: 8.4
             experimental: false
+          - mw: 'REL1_46'
+            php: 8.5
+            experimental: false
+          - mw: 'master'
+            php: 8.5
+            experimental: true
 
     runs-on: ubuntu-latest
 
@@ -80,4 +86,14 @@ jobs:
         run: composer update
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php --group skins-chameleon
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php --group skins-chameleon
+          else
+            # MW 1.46 and later
+            if [ ! -f phpunit.xml.template ]; then
+              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+            fi
+            composer phpunit:config
+            vendor/bin/phpunit --group skins-chameleon
+          fi

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"composer/installers": "^2|^1.0.12",
 		"mediawiki/bootstrap": "^5.0",
 		"jeroen/file-fetcher": "^6",
-		"psr/http-message": "^1"
+		"psr/http-message": "^1|^2"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "47.0.0",


### PR DESCRIPTION
## Why

MediaWiki 1.46 moves core to `psr/http-message: 2.0`. The 5.x line pinned
`psr/http-message: ^1`, so composer refused to resolve against 1.46 and the
skin could not be installed there.

Chameleon's own code never references psr/http-message; the constraint only
ever pinned a transitive dependency. Widening it to `^1|^2` is therefore
behaviourally inert for the skin and simply lets it coexist with core's v2.

## Changes

- **composer.json:** widen `psr/http-message` to `^1|^2`. Installs on 1.46+;
  every existing 1.39 to 1.45 environment (which pins v1 in core) resolves
  identically, so no currently supported version changes.
- **CI:** add a required `REL1_46` row. 1.46 removed `tests/phpunit/phpunit.php` in
  favour of `composer phpunit:config` + `vendor/bin/phpunit`. The PHPUnit step
  now picks the runner by detecting whether the old entry point still exists,
  so one step covers 1.46, master, and later versions without a per-version
  condition in the matrix.

With the widening, 5.x installs on 1.46 and passes its full test suite there,
so 1.46 is added as a required version. A `master` (1.47-dev) row is also
added as experimental / non-blocking, to surface breakage against the
development tip early.

For #404


