### PR TITLE
Detect the PHPUnit runner instead of matching the MW version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,21 +76,15 @@ jobs:
       - name: Composer update
         run: composer update
 
-      # "master" currently tracks MW >= 1.46, where tests/phpunit/phpunit.php
-      # was removed. Once REL1_46 lands in the matrix, it needs the master
-      # invocation below as well.
-      - name: Run PHPUnit (MW < master)
-        if: matrix.mw != 'master'
-        run: php tests/phpunit/phpunit.php --group skins-chameleon
-
-      - name: Run PHPUnit (MW master)
-        if: matrix.mw == 'master'
+      - name: Run PHPUnit
         run: |
-          # TODO: phpunit.xml.template is export-ignored from GitHub's tarball
-          # archive, so we fetch it separately. Remove this once installWiki.sh
-          # switches to `git clone`, or MW drops the export-ignore.
-          if [ ! -f phpunit.xml.template ]; then
-            wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php --group skins-chameleon
+          else
+            # MW 1.46 and later
+            if [ ! -f phpunit.xml.template ]; then
+              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+            fi
+            composer phpunit:config
+            vendor/bin/phpunit --group skins-chameleon
           fi
-          composer phpunit:config
-          vendor/bin/phpunit --group skins-chameleon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           - mw: 'REL1_45'
             php: 8.3
             experimental: false
-          - mw: 'master'
+          - mw: 'REL1_46'
             php: 8.4
-            experimental: true
+            experimental: false
           - mw: 'master'
             php: 8.5
             experimental: true


### PR DESCRIPTION
## Why

The PHPUnit step gated the new runner on `matrix.mw == 'master'`. MediaWiki 1.46
removed `tests/phpunit/phpunit.php` in favour of `composer phpunit:config` +
`vendor/bin/phpunit`, and every version after it does the same, so the version
string match would need editing for each new row. The workflow already carried a
TODO saying exactly that for REL1_46, and a row that was forgotten would silently
run the wrong runner and fail.

## Change

Pick the runner by detecting whether the old entry point still exists, rather
than matching a version string. One step now covers MW < 1.46 (old entry point)
and 1.46+/master (new config-generation path) with no per-version condition.

With that in place, add a required `REL1_46` row to the matrix; it needs no
special handling. Mirrors the same handling added to the 5.x line in #490.

