### PR TITLE
Match the master branch CI PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
             php: 8.3
             experimental: false
           - mw: 'REL1_45'
-            php: 8.4
+            php: 8.3
             experimental: false
           - mw: 'REL1_46'
-            php: 8.5
+            php: 8.4
             experimental: false
           - mw: 'master'
             php: 8.5


### PR DESCRIPTION
Align the 5.x matrix's recent rows with the master branch (and MediaWiki's own
newest-three test cadence): run REL1_45 on PHP 8.3 and REL1_46 on PHP 8.4,
leaving PHP 8.5 on the experimental `master` row.

Both 8.4 and 8.5 are supported by MediaWiki 1.46, so this is a coverage and
consistency choice across the two branches, not a support limit.

Follow-up to #490.