### PR TITLE
Prepare for release 5.0.3

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 ## Release Notes
 
+### Chameleon 5.0.3
+
+Released on June 11, 2026.
+
+* Added the Wikibase "Edit links" / "Add links" link to the language menu (thanks @malberts)
+* Added initial compatibility with MediaWiki 1.46 (thanks @malberts)
+
 ### Chameleon 5.0.2
 
 Released on November 14, 2025.

--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
 		"Morne Alberts",
 		"[https://www.EntropyWins.wtf/mediawiki Jeroen De Dauw]"
 	],
-	"version": "5.0.2",
+	"version": "5.0.3",
 	"url": "https://www.mediawiki.org/wiki/Skin:Chameleon",
 	"descriptionmsg": "chameleon-desc",
 	"license-name": "GPL-3.0-or-later",


### PR DESCRIPTION
Prepares the 5.0.3 release: version bump in `skin.json` plus the
`docs/release-notes.md` entry.

User-facing changes since 5.0.2:
- The Wikibase "Edit links" / "Add links" link now appears in the language menu.
- Compatibility with MediaWiki 1.46 (psr/http-message `^1|^2`).

The CI and build-infra commits since 5.0.2 (advisory-install workaround, PHP and
matrix updates) are intentionally not listed, matching the changelog's
user-facing focus.
