### PR TITLE
Add version 5.0.3 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,13 @@ Under development.
 * Added initial Bootstrap 5.3.8 compatibility (thanks @malberts)
 * Removed the Bootstrap 4 `.pull-left`/`.pull-right` compatibility classes
 
+### Chameleon 5.0.3
+
+Released on June 11, 2026.
+
+* Added the Wikibase "Edit links" / "Add links" link to the language menu (thanks @malberts)
+* Added initial compatibility with MediaWiki 1.46 (thanks @malberts)
+
 ### Chameleon 5.0.2
 
 Released on November 14, 2025.


### PR DESCRIPTION
Records the 5.0.3 release (cut from `5.x`) in the changelog on master, so the
notes stay complete across branches. Matches how earlier maintenance releases
are listed (for example 4.4.1 and 4.4.2).

No version change: master stays `6.0.0-dev`; only `docs/release-notes.md` is touched.
