### PR TITLE
Use bundled SVG for the logo instead of a Wikimedia hotlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Stable Version](https://poser.pugx.org/mediawiki/chameleon-skin/v/stable)](https://packagist.org/packages/mediawiki/chameleon-skin)
 [![Packagist download count](https://poser.pugx.org/mediawiki/chameleon-skin/downloads)](https://packagist.org/packages/mediawiki/chameleon-skin)
 
-<img src='https://upload.wikimedia.org/wikipedia/mediawiki/thumb/3/31/Chameleon.svg/220px-Chameleon.svg.png' style='float:left;' align="left" title='Chameleon Skin Logo'>
+<img src='docs/Chameleon.svg' width='220' style='float:left;' align="left" title='Chameleon Skin Logo'>
 
 Chameleon is a highly customizable [MediaWiki][mw] skin that uses the
 [Bootstrap][twbs] framework.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # The Chameleon Documentation
 
-<img src='https://upload.wikimedia.org/wikipedia/mediawiki/thumb/3/31/Chameleon.svg/220px-Chameleon.svg.png' align='left' title='Chameleon Skin Logo'>
+<img src='Chameleon.svg' width='220' align='left' title='Chameleon Skin Logo'>
 
 Chameleon is a highly customizable [MediaWiki][mw] skin that uses the
 [Bootstrap][twbs] framework.


### PR DESCRIPTION
The README and docs landing-page logo were hotlinked from `upload.wikimedia.org` at a 220px thumbnail width. Wikimedia now rejects hotlinked thumbnails at non-standard widths with HTTP 400, and 220px is not on the permitted list (20, 40, 60, 120, 250, 330, 500, 960, 1280, 1920, 3840), so the logo no longer renders on the repo front page or the docs site.

The same artwork is already bundled in the repo at `docs/Chameleon.svg`, so both `<img>` tags now point at the local file (`docs/Chameleon.svg` from the README, `Chameleon.svg` from `docs/index.md`). `width='220'` is set so the logo keeps its previous size; the SVG's intrinsic width is ~170px.

The remaining `upload.wikimedia.org` reference in `docs/components.md` is a 170px URL inside an indented code example, so it renders as a code block rather than an image and is out of scope here.

Ref: https://www.mediawiki.org/wiki/Common_thumbnail_sizes
