### PR TITLE
CI: switch the install script to git clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v20
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v21
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -91,9 +91,6 @@ jobs:
             php tests/phpunit/phpunit.php --group skins-chameleon
           else
             # MW 1.46 and later
-            if [ ! -f phpunit.xml.template ]; then
-              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
-            fi
             composer phpunit:config
             vendor/bin/phpunit --group skins-chameleon
           fi

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -3,10 +3,7 @@
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 
-wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki.git mediawiki
 
 cd mediawiki
 


### PR DESCRIPTION
Fixes latent install-script bitrot affecting REL1_39, REL1_41, and REL1_42, and drops the now-redundant wget for `phpunit.xml.template`.

## Switch the install script to `git clone`

Wikimedia recently converted older MediaWiki release refs (REL1_39 through REL1_42, plus older extension/skin branches) from branches to tags. The original branch refs still exist for now, so the same names resolve as both a branch AND a tag. GitHub's archive endpoint can no longer disambiguate the bare `archive/<name>.tar.gz` URL form in that state, and returns an HTTP 300 Multiple Choices with a 105-byte body:

> the given path has multiple possibilities: #<Git::Ref:...>, #<Git::Ref:...>

The matrix's REL1_39, REL1_41, and REL1_42 rows are currently passing only because the install step is gated on a cache hit, and the cached MediaWiki trees were populated from the pre-conversion wget era. Cache eviction (7-day inactivity on a given key, or the cache-key bump in this PR) would tip them red. Switching `installWiki.sh` to `git clone --depth 1 --branch <name>` resolves whichever ref form exists and is robust to whatever Wikimedia does with the refs next.

## Drop the redundant wget for `phpunit.xml.template`

The new-runner code path (1.46+) was fetching `phpunit.xml.template` from `raw.githubusercontent.com` because MediaWiki marks the file `export-ignore` in `.gitattributes`, which excludes it from `git archive` output (and therefore from GitHub's `archive/<ref>.tar.gz` tarball endpoint). `git clone` does not honour `export-ignore`; the file is in the working tree after a normal checkout. With `installWiki.sh` now using `git clone`, the separate wget becomes dead code.

## Bump the cache key

Existing wget-era cache entries (`-v20`) lack `phpunit.xml.template` because they were populated from the archive tarball. Without a key bump, on every cache hit after merge the file would be absent and `composer phpunit:config` would fail. Bump to `-v21` so the next run on each cache key produces a fresh entry from the `git clone` path, with the file included.